### PR TITLE
fix nested dichotomous execution and memory allocation

### DIFF
--- a/src/code_base/bmds_helper.cpp
+++ b/src/code_base/bmds_helper.cpp
@@ -3548,7 +3548,6 @@ void Nlogist_Bootstrap(struct nestedObjData *objData, struct python_nested_resul
     }
   }
   sort(combSR.begin(), combSR.end());
-  pyRes->boot.pVal[BSLoops+1] = pavg;
   for (int k=0; k<percentiles.size(); k++){
     double temp = percentiles[k] * BSLoops*iterations;
     if ((ceilf(temp)==temp) && (floorf(temp)==temp)){

--- a/src/pybmds/datasets/nested_dichotomous.py
+++ b/src/pybmds/datasets/nested_dichotomous.py
@@ -23,9 +23,9 @@ class NestedDichotomousDataset(DatasetBase):
     def __init__(
         self,
         doses: list[float],
-        litter_ns: list[int],
+        litter_ns: list[float],
         incidences: list[float],
-        litter_covariates: list[int],
+        litter_covariates: list[float],
         **metadata,
     ):
         self.doses = doses

--- a/src/pybmds/models/nested_dichotomous.py
+++ b/src/pybmds/models/nested_dichotomous.py
@@ -51,26 +51,12 @@ class BmdModelNestedDichotomous(BmdModel):
         return PriorClass.frequentist_restricted
 
     def to_cpp(self) -> NestedDichotomousAnalysis:
-        structs = NestedDichotomousAnalysis.blank()
-        structs.analysis.model = self.model_class
-        structs.analysis.doses = self.dataset.doses
-        structs.analysis.litterSize = self.dataset.litter_ns
-        structs.analysis.incidence = self.dataset.incidences
-        structs.analysis.lsc = self.dataset.litter_covariates
-        structs.analysis.prior = self.settings.priors.to_c_nd(self.dataset.num_dose_groups)
-        structs.analysis.LSC_type = self.settings.litter_specific_covariate.value
-        structs.analysis.ILC_type = self.settings.intralitter_correlation.value
-        structs.analysis.BMD_type = self.settings.bmr_type.value
-        structs.analysis.estBackground = self.settings.estimate_background
-        structs.analysis.parms = len(self.get_param_names())
-        structs.analysis.prior_cols = 2
-        structs.analysis.BMR = self.settings.bmr
-        structs.analysis.alpha = self.settings.alpha
-        structs.analysis.numBootRuns = self.settings.bootstrap_n
-        structs.analysis.iterations = self.settings.bootstrap_iterations
-        structs.analysis.seed = self.settings.bootstrap_seed
-
-        return structs
+        return NestedDichotomousAnalysis.create(
+            model_class=self.model_class,
+            nparms=len(self.get_param_names()),
+            dataset=self.dataset,
+            settings=self.settings,
+        )
 
     def execute(self) -> NestedDichotomousResult:
         self.structs = self.to_cpp()

--- a/src/pybmds/types/dichotomous.py
+++ b/src/pybmds/types/dichotomous.py
@@ -104,6 +104,7 @@ class DichotomousAnalysis(BaseModel):
     degree: int
     samples: int
     burnin: int
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property


### PR DESCRIPTION
Fix segfault occurring in mac environment. We were setting a value out of bounds of the array; likely a bug from migrating from fortran to C++.

In addition, refactor how nested dichotomous C++ structs are being built in Python to be more consistent with continuous and dichotomous.