### PR TITLE
remove gof_cancer rule from default logic but allow it if it exists

### DIFF
--- a/src/pybmds/recommender/default.json
+++ b/src/pybmds/recommender/default.json
@@ -53,14 +53,6 @@
             "enabled_nested": true
         },
         {
-            "rule_class": "gof_cancer",
-            "failure_bin": 1,
-            "threshold": 0.05,
-            "enabled_dichotomous": false,
-            "enabled_continuous": false,
-            "enabled_nested": false
-        },
-        {
             "rule_class": "aic_missing",
             "failure_bin": 2,
             "threshold": null,

--- a/src/pybmds/recommender/recommender.py
+++ b/src/pybmds/recommender/recommender.py
@@ -55,9 +55,9 @@ class RecommenderSettings(BaseModel):
     @field_validator("rules")
     @classmethod
     def rules_all_classes(cls, rules):
-        rule_classes = set(rule.rule_class for rule in rules)
-        all_rule_classes = set(RuleClass.__members__)
-        missing = all_rule_classes - rule_classes
+        required_rules = set(RuleClass.__members__) - {RuleClass.gof_cancer}
+        rules_set = set(rule.rule_class for rule in rules)
+        missing = required_rules - rules_set
         if missing:
             raise ValueError(f"Rule list must be complete; missing {missing}")
         return rules

--- a/tests/test_pybmds/tests/recommender/test_recommender.py
+++ b/tests/test_pybmds/tests/recommender/test_recommender.py
@@ -1,8 +1,10 @@
+import json
+
 import pytest
 from pydantic import ValidationError
 
 import pybmds
-from pybmds.recommender.recommender import Recommender, RecommenderSettings
+from pybmds.recommender.recommender import Recommender, RecommenderSettings, default_rules_text
 
 
 class TestRecommenderSettings:
@@ -20,11 +22,28 @@ class TestRecommenderSettings:
             RecommenderSettings.model_validate(settings2)
         assert "Rule list must be complete" in str(err)
 
+    def test_optional_rule(self):
+        rules = json.loads(default_rules_text())
+        RecommenderSettings.model_validate(rules)
+        assert "gof_cancer" not in {rule["rule_class"] for rule in rules["rules"]}
+
+        rules["rules"].append(
+            {
+                "rule_class": "gof_cancer",
+                "failure_bin": 1,
+                "threshold": 0.05,
+                "enabled_dichotomous": False,
+                "enabled_continuous": False,
+                "enabled_nested": False,
+            }
+        )
+        RecommenderSettings.model_validate(rules)
+
 
 class TestRecommender:
     def test_df(self):
         df = Recommender().settings.to_df()
-        assert df.shape == (22, 6)
+        assert df.shape == (21, 6)
 
 
 class TestSessionRecommender:


### PR DESCRIPTION
Before inclusion of the multistage cancer/multitumor model, a model recommendation rule existed to optionally set the goodness of fit threshold to 0.05 instead of 0.1 for cancer datasets.  Remove this option from the default since it is no longer needed; but allow it to be optionally specified for backwards compatibility of existing datasets.