### PR TITLE
deploy documentation to static sites

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,6 @@
 name: Deploy Documentation
 
 on:
-  pull_request:  # TODO - remove this line
   schedule:
     - cron: '30 3 1 */1 *'  # At 03:30 on the 1st of every month
   push:
@@ -10,7 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-docs:
+  build:
+    name: Build Documentation
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -35,14 +35,14 @@ jobs:
         with:
           path: docs/build/html
 
-  deploy-pages:
-    name: Deploy documentation to GitHub Pages
-    needs: build-docs
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,54 @@
+name: Deploy Documentation
+
+on:
+  pull_request:  # TODO - remove this line
+  schedule:
+    - cron: '30 3 1 */1 *'  # At 03:30 on the 1st of every month
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          source ./tools/linux_ci_setup.sh
+      - name: Build pybmds
+        run: |
+          source ./tools/linux_ci_env.sh
+          python -m pip install -U pip wheel
+          python -m pip install -e ".[docs]"
+      - name: Build documentation
+        run: |
+          make docs
+      - name: Upload Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/build/html
+
+  deploy-pages:
+    name: Deploy documentation to GitHub Pages
+    needs: build-docs
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -43,24 +43,24 @@ jobs:
           stubgen -p pybmds.bmdscore -o src
           ruff format src/pybmds/bmdscore.pyi
           python -c "import pybmds; print(pybmds.bmdscore.version())"
-      - name: Check linked files
-        run: |
-          ls -lah src/pybmds
-          ldd src/pybmds/bmdscore*.so
-      - name: loc
-        run: |
-          sudo apt-get install -y cloc
-          echo "# Lines of Code Report" >> $GITHUB_STEP_SUMMARY
-          make loc >> $GITHUB_STEP_SUMMARY
-      - name: Check linting
-        run: |
-          make lint
-      - name: Test with pytest
-        run: |
-          coverage run -m pytest
-          echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
-          coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
-          coverage html -d coverage -i
+      # - name: Check linked files
+      #   run: |
+      #     ls -lah src/pybmds
+      #     ldd src/pybmds/bmdscore*.so
+      # - name: loc
+      #   run: |
+      #     sudo apt-get install -y cloc
+      #     echo "# Lines of Code Report" >> $GITHUB_STEP_SUMMARY
+      #     make loc >> $GITHUB_STEP_SUMMARY
+      # - name: Check linting
+      #   run: |
+      #     make lint
+      # - name: Test with pytest
+      #   run: |
+      #     coverage run -m pytest
+      #     echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
+      #     coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+      #     coverage html -d coverage -i
       - name: Build documentation
         run: |
           make docs
@@ -75,42 +75,46 @@ jobs:
           name: docs
           path: docs/build/html
           retention-days: 14
-      - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4
+      - name: Upload Pages
+        uses: actions/upload-pages-artifact@v1
         with:
-          name: coverage
-          path: coverage
-          retention-days: 14
+          path: docs/build/html
+      # - name: Upload Coverage Report
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: coverage
+      #     path: coverage
+      #     retention-days: 14
 
   bmdscore:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          source ./tools/linux_ci_setup.sh
-      - name: Run clang-format
-        run: |
-          pip install clang-format==19.1.3
-          make format-cpp
-          git diff --exit-code --compact-summary || { echo "Code formatting failed; run 'make format-cpp'"; exit 1; }
-      - name: Build bmdscore
-        run: |
-          source ./tools/linux_ci_env.sh
-          mkdir -p src/build
-          cd src/build
-          cmake ..
-          make -j$(nproc)
-      - name: Run tests and generate report
-        run: |
-          source ./tools/linux_ci_env.sh
-          cd src/build
-          make run_tests_with_coverage
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cpp-coverage
-          path: |
-            ./src/build/coverage/*
+      # - name: Install dependencies
+      #   run: |
+      #     source ./tools/linux_ci_setup.sh
+      # - name: Run clang-format
+      #   run: |
+      #     pip install clang-format==19.1.3
+      #     make format-cpp
+      #     git diff --exit-code --compact-summary || { echo "Code formatting failed; run 'make format-cpp'"; exit 1; }
+      # - name: Build bmdscore
+      #   run: |
+      #     source ./tools/linux_ci_env.sh
+      #     mkdir -p src/build
+      #     cd src/build
+      #     cmake ..
+      #     make -j$(nproc)
+      # - name: Run tests and generate report
+      #   run: |
+      #     source ./tools/linux_ci_env.sh
+      #     cd src/build
+      #     make run_tests_with_coverage
+      # - uses: actions/upload-artifact@v4
+      #   with:
+      #     name: cpp-coverage
+      #     path: |
+      #       ./src/build/coverage/*
 
   docs:
     name: Deploy documentation to GitHub Pages
@@ -125,9 +129,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v3
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
-        with:
-          artifact_name: docs
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -110,3 +110,23 @@ jobs:
           name: cpp-coverage
           path: |
             ./src/build/coverage/*
+
+  docs:
+    name: Deploy documentation to GitHub Pages
+    needs: pybmds
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: docss

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,7 +1,7 @@
 name: Test Linux
 
 on:
-  pull_request:
+  # pull_request: TODO - uncomment this line
   push:
     branches:
       - main
@@ -43,93 +43,70 @@ jobs:
           stubgen -p pybmds.bmdscore -o src
           ruff format src/pybmds/bmdscore.pyi
           python -c "import pybmds; print(pybmds.bmdscore.version())"
-      # - name: Check linked files
-      #   run: |
-      #     ls -lah src/pybmds
-      #     ldd src/pybmds/bmdscore*.so
-      # - name: loc
-      #   run: |
-      #     sudo apt-get install -y cloc
-      #     echo "# Lines of Code Report" >> $GITHUB_STEP_SUMMARY
-      #     make loc >> $GITHUB_STEP_SUMMARY
-      # - name: Check linting
-      #   run: |
-      #     make lint
-      # - name: Test with pytest
-      #   run: |
-      #     coverage run -m pytest
-      #     echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
-      #     coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
-      #     coverage html -d coverage -i
+      - name: Check linked files
+        run: |
+          ls -lah src/pybmds
+          ldd src/pybmds/bmdscore*.so
+      - name: loc
+        run: |
+          sudo apt-get install -y cloc
+          echo "# Lines of Code Report" >> $GITHUB_STEP_SUMMARY
+          make loc >> $GITHUB_STEP_SUMMARY
+      - name: Check linting
+        run: |
+          make lint
+      - name: Test with pytest
+        run: |
+          coverage run -m pytest
+          echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
+          coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+          coverage html -d coverage -i
       - name: Build documentation
         run: |
           make docs
           if [ "$generateDocx" = "true" ]; then
             make docs-docx
-            mv docs/build/pybmds.docx docs/build/html/pybmds.docx
+            rm -rf docs/build/singlehtml
           fi
-          chmod -R a+rX docs/build/html  # required for github pages
       - name: Upload Documentation
         uses: actions/upload-artifact@v4
         with:
           name: docs
-          path: docs/build/html
+          path: docs/build/
           retention-days: 14
-      - name: Upload Pages
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v4
         with:
-          path: docs/build/html
-      # - name: Upload Coverage Report
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: coverage
-      #     path: coverage
-      #     retention-days: 14
+          name: coverage
+          path: coverage
+          retention-days: 14
 
   bmdscore:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      # - name: Install dependencies
-      #   run: |
-      #     source ./tools/linux_ci_setup.sh
-      # - name: Run clang-format
-      #   run: |
-      #     pip install clang-format==19.1.3
-      #     make format-cpp
-      #     git diff --exit-code --compact-summary || { echo "Code formatting failed; run 'make format-cpp'"; exit 1; }
-      # - name: Build bmdscore
-      #   run: |
-      #     source ./tools/linux_ci_env.sh
-      #     mkdir -p src/build
-      #     cd src/build
-      #     cmake ..
-      #     make -j$(nproc)
-      # - name: Run tests and generate report
-      #   run: |
-      #     source ./tools/linux_ci_env.sh
-      #     cd src/build
-      #     make run_tests_with_coverage
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #     name: cpp-coverage
-      #     path: |
-      #       ./src/build/coverage/*
-
-  docs:
-    name: Deploy documentation to GitHub Pages
-    needs: pybmds
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Install dependencies
+        run: |
+          source ./tools/linux_ci_setup.sh
+      - name: Run clang-format
+        run: |
+          pip install clang-format==19.1.3
+          make format-cpp
+          git diff --exit-code --compact-summary || { echo "Code formatting failed; run 'make format-cpp'"; exit 1; }
+      - name: Build bmdscore
+        run: |
+          source ./tools/linux_ci_env.sh
+          mkdir -p src/build
+          cd src/build
+          cmake ..
+          make -j$(nproc)
+      - name: Run tests and generate report
+        run: |
+          source ./tools/linux_ci_env.sh
+          cd src/build
+          make run_tests_with_coverage
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cpp-coverage
+          path: |
+            ./src/build/coverage/*

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -76,7 +76,7 @@ jobs:
           path: docs/build/html
           retention-days: 14
       - name: Upload Pages
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs/build/html
       # - name: Upload Coverage Report

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -66,13 +66,13 @@ jobs:
           make docs
           if [ "$generateDocx" = "true" ]; then
             make docs-docx
-            rm -rf docs/build/singlehtml
+            mv docs/build/pybmds.docx docs/build/html/pybmds.docx
           fi
       - name: Upload Documentation
         uses: actions/upload-artifact@v4
         with:
           name: docs
-          path: docs/build/
+          path: docs/build/html
           retention-days: 14
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4
@@ -129,4 +129,4 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
         with:
-          artifact_name: docss
+          artifact_name: docs

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -68,6 +68,7 @@ jobs:
             make docs-docx
             mv docs/build/pybmds.docx docs/build/html/pybmds.docx
           fi
+          chmod -R a+rX docs/build/html  # required for github pages
       - name: Upload Documentation
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,7 +1,7 @@
 name: Test Linux
 
 on:
-  # pull_request: TODO - uncomment this line
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -129,7 +129,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,12 +19,13 @@ build:
   jobs:
     pre_install:
       # copied from `tools/linux_ci_env.sh`
-      - ls /usr/lib/
+      - ls /usr/lib/x86_64-linux-gnu/
       - export EIGEN_DIR="/usr/include/eigen3"
-      - export NLOPT_DIR="/usr/lib/aarch64-linux-gnu/"
+      - export NLOPT_DIR="/usr/lib/x86_64-linux-gnu/"
       - export CMAKE_C_COMPILER="/usr/bin/gcc-11"
       - export CMAKE_CXX_COMPILER="/usr/bin/g++-11"
       - export TEST_EXC="'/usr/include/*'"
+      - env
 sphinx:
   configuration: docs/source/conf.py
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,8 @@ build:
     - libnlopt-cxx-dev
   jobs:
     pre_install:
+      - pwd
+      - cat ./tools/linux_ci_env.sh
       - source ./tools/linux_ci_env.sh
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
   apt_packages:
@@ -18,8 +18,13 @@ build:
     - libnlopt-cxx-dev
   jobs:
     pre_install:
+      - ls -laht
+      - ls -laht /usr/lib/
+      - ls -laht /usr/include/eigen3
+      - ls -laht /usr/bin/
+      - ls -laht /usr/lib/x86_64-linux-gnu/
+      - ls -laht /usr/include/
       # copied from `tools/linux_ci_env.sh`
-      - ls /usr/lib/x86_64-linux-gnu/
       - export EIGEN_DIR="/usr/include/eigen3"
       - export NLOPT_DIR="/usr/lib/x86_64-linux-gnu/"
       - export CMAKE_C_COMPILER="/usr/bin/gcc-11"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
-  os: ubuntu-24.04
+  os: ubuntu-22.04
   tools:
     python: "3.12"
   apt_packages:
@@ -18,18 +18,14 @@ build:
     - libnlopt-cxx-dev
   jobs:
     pre_install:
+      # environment variables configured in readthedocs web admin
+      # variables the same as those in `tools/linux_ci_setup.sh`
       - ls -laht
       - ls -laht /usr/lib/
       - ls -laht /usr/include/eigen3
       - ls -laht /usr/bin/
       - ls -laht /usr/lib/x86_64-linux-gnu/
       - ls -laht /usr/include/
-      # copied from `tools/linux_ci_env.sh`
-      - export EIGEN_DIR="/usr/include/eigen3"
-      - export NLOPT_DIR="/usr/lib/x86_64-linux-gnu/"
-      - export CMAKE_C_COMPILER="/usr/bin/gcc-11"
-      - export CMAKE_CXX_COMPILER="/usr/bin/g++-11"
-      - export TEST_EXC="'/usr/include/*'"
       - env
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,28 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+  apt_packages:
+    - automake
+    - build-essential
+    - libtool
+    - make
+    - cmake
+    - libgslcblas0
+    - libgsl-dev
+    - libeigen3-dev
+    - libnlopt-dev
+    - libnlopt-cxx-dev
+  jobs:
+    pre_install:
+      - source ./tools/linux_ci_env.sh
+sphinx:
+  configuration: docs/source/conf.py
+python:
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+      - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,12 +20,6 @@ build:
     pre_install:
       # environment variables configured in readthedocs web admin
       # variables the same as those in `tools/linux_ci_setup.sh`
-      - ls -laht
-      - ls -laht /usr/lib/
-      - ls -laht /usr/include/eigen3
-      - ls -laht /usr/bin/
-      - ls -laht /usr/lib/x86_64-linux-gnu/
-      - ls -laht /usr/include/
       - env
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,7 @@ build:
   tools:
     python: "3.12"
   apt_packages:
+    # copied from `tools/linux_ci_setup.sh`
     - automake
     - build-essential
     - libtool
@@ -17,9 +18,12 @@ build:
     - libnlopt-cxx-dev
   jobs:
     pre_install:
-      - pwd
-      - cat ./tools/linux_ci_env.sh
-      - source ./tools/linux_ci_env.sh
+      # copied from `tools/linux_ci_env.sh`
+      - export EIGEN_DIR="/usr/include/eigen3"
+      - export NLOPT_DIR="/usr/lib/x86_64-linux-gnu/"
+      - export CMAKE_C_COMPILER="/usr/bin/gcc-11"
+      - export CMAKE_CXX_COMPILER="/usr/bin/g++-11"
+      - export TEST_EXC="'/usr/include/*'"
 sphinx:
   configuration: docs/source/conf.py
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,8 +19,9 @@ build:
   jobs:
     pre_install:
       # copied from `tools/linux_ci_env.sh`
+      - ls /usr/lib/
       - export EIGEN_DIR="/usr/include/eigen3"
-      - export NLOPT_DIR="/usr/lib/x86_64-linux-gnu/"
+      - export NLOPT_DIR="/usr/lib/aarch64-linux-gnu/"
       - export CMAKE_C_COMPILER="/usr/bin/gcc-11"
       - export CMAKE_CXX_COMPILER="/usr/bin/g++-11"
       - export TEST_EXC="'/usr/include/*'"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,34 @@
 # BMDS
 
+<table>
+<tbody>
+<tr>
+    <td>Package</td><td>
+
+[![version](https://img.shields.io/pypi/v/pybmds.svg?label=pybmds%20version&maxAge=3600)](https://pypi.org/project/pybmds/)
+[![version](https://img.shields.io/pypi/v/bmds-ui.svg?label=bmds-ui%20version&maxAge=3600)](https://pypi.org/project/bmds-ui/)
+    </td>
+</tr>
+<tr>
+    <td>Documentation</td><td>
+
+[![Docs Badge](https://img.shields.io/badge/Latest-online-brightgreen)](https://usepa.github.io/BMDS) [![Read The Docs](https://img.shields.io/badge/Versioned-online-brightgreen)](https://pybmds.readthedocs.io/)
+    </td>
+</tr>
+<tr>
+    <td>Website</td><td>
+
+[![Site Badge](https://img.shields.io/badge/BMDS-online-purple)](https://epa.gov/bmds) [![Site Badge](https://img.shields.io/badge/BMDS&nbsp;Online-online-purple)](https://bmdsonline.epa.gov)
+    </td>
+</tr>
+
+</tbody>
+</table>
+
+
 EPA's Benchmark Dose Software (BMDS) collects and provides easy access to numerous mathematical models that help risk assessors estimate the quantitative relationship between a chemical dose and the test subject’s response.  A specific focus of BMDS is estimating a statistical benchmark dose (BMD). The BMD is a chemical dose or concentration that produces a predetermined change in the response rate of an adverse effect, such as weight loss or tumor incidence. The BMD is a range, rather than a fixed number. For example, the benchmark dose (lower confidence limit) (BMDL) can be regarded as a dose where the observable physical effect is less than the predetermined benchmark response (BMR).
 
-![An example dose response plot an and curve fit](tests/test_pybmds/data/mpl/test_dichotomous_plot.png)
+![An example dose response plot an and curve fit](https://github.com/USEPA/BMDS/raw/e89f79388dc3021604e1230ac75e721c12c6bf61/tests/test_pybmds/data/mpl/test_dichotomous_plot.png)
 
 Additional information, documentation, and technical guidance for BMDS is available at [https://www.epa.gov/bmds](https://www.epa.gov/bmds).
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,7 +1,7 @@
 project = "pybmds"
 copyright = "MIT License"
 
-extensions = ["myst_nb", "sphinx_design"]
+extensions = ["sphinx.ext.githubpages", "myst_nb", "sphinx_design"]
 souce_suffix = {
     ".md": "markdown",
     ".rst": "restructuredtext",


### PR DESCRIPTION
Through trial and error, deploy `pybmds` documentation to two locations:

1. https://usepa.github.io/BMDS/. This shows documentation for the latest tagged (released) version and is appealing as it has the U.S. EPA GitHub subdomain as part of the URL.  This is triggered automatically whenever a tag is applied to the git repository.
2. https://pybmds.readthedocs.io/. This shows documentation for current and prior tagged versions, so it may be useful for people working with older versions of the software.  This capability is not available using the github.io subdomain without significant effort. This is triggered manually. 

In addition, added assorted badges to home page of the GitHub readme for the BMDS repository, now that documentation is available.