### PR TITLE
add BMD to plotting range

### DIFF
--- a/src/pybmds/datasets/base.py
+++ b/src/pybmds/datasets/base.py
@@ -74,12 +74,21 @@ class DatasetBase(abc.ABC):
     def to_dict(self):
         return self.serialize().model_dump()
 
-    @property
-    def dose_linspace(self) -> np.ndarray:
-        if not hasattr(self, "_dose_linspace"):
-            self._dose_linspace = np.linspace(np.min(self.doses), np.max(self.doses), 100)
-            self._dose_linspace[self._dose_linspace == 0] = ZEROISH
-        return self._dose_linspace
+    def dose_linspace(self, extra_values: list | None = None, n: int = 100) -> np.ndarray:
+        """Return a numpy array of size n between the minimum dose and maximum dose.
+
+        Args:
+            extra_values (list | None, optional): Any extra values that should be in the domain
+            n (int, optional): Size of array; defaults to 100.
+
+        Returns:
+            np.ndarray: A 1D numpy array between the zeroish min dose and the maximum dose
+        """
+        values = extra_values or []
+        values.extend(self.doses)
+        xs = np.linspace(np.min(values), np.max(values), n)
+        xs[xs == 0] = ZEROISH
+        return xs
 
     def _get_dose_units_text(self) -> str:
         if self.metadata.dose_units:

--- a/src/pybmds/models/base.py
+++ b/src/pybmds/models/base.py
@@ -159,6 +159,13 @@ class BmdModel(abc.ABC):
             self.results.plotting.dr_y,
             **plotting.LINE_FORMAT,
         )
+
+        # if the BMD is greater than the current plot domain, extend to 105% of BMD
+        xlim = ax.get_xlim()
+        bmd = self.results.get_parameter("bmd")
+        if bmd > xlim[1]:
+            ax.set_xlim(xlim[0], bmd * 1.05)
+
         self._plot_bmr_lines(ax, axlines=axlines)
         slope_factor = getattr(self.results, "slope_factor", None)
         if draw_slope := slope_factor and slope_factor > 0:

--- a/src/pybmds/types/continuous.py
+++ b/src/pybmds/types/continuous.py
@@ -535,7 +535,8 @@ class ContinuousPlotting(BaseModel):
     def from_model(cls, model, params) -> Self:
         summary = model.structs.result.bmdsRes
         xs = np.array([summary.BMDL, summary.BMD, summary.BMDU])
-        dr_x = model.dataset.dose_linspace
+        extra_values = [summary.BMD] if summary.BMD >= 0 else []
+        dr_x = model.dataset.dose_linspace(extra_values=extra_values)
         dr_y = clean_array(model.dr_curve(dr_x, params))
         critical_ys = clean_array(model.dr_curve(xs, params))
         critical_ys[critical_ys <= 0] = constants.BMDS_BLANK_VALUE

--- a/src/pybmds/types/dichotomous.py
+++ b/src/pybmds/types/dichotomous.py
@@ -386,7 +386,8 @@ class DichotomousPlotting(BaseModel):
         result = model.structs.result
         summary = result.bmdsRes
         xs = np.array([summary.BMDL, summary.BMD, summary.BMDU])
-        dr_x = model.dataset.dose_linspace
+        extra_values = [summary.BMD] if summary.BMD >= 0 else []
+        dr_x = model.dataset.dose_linspace(extra_values=extra_values)
         dr_y = clean_array(model.dr_curve(dr_x, params))
         critical_ys = clean_array(model.dr_curve(xs, params))
         critical_ys[critical_ys <= 0] = constants.BMDS_BLANK_VALUE

--- a/src/pybmds/types/nested_dichotomous.py
+++ b/src/pybmds/types/nested_dichotomous.py
@@ -274,7 +274,8 @@ class Plotting(BaseModel):
     def from_model(cls, model, params: dict, fixed_lsc: float) -> Self:
         summary = model.structs.result.bmdsRes
         xs = np.array([summary.BMDL, summary.BMD, summary.BMDU])
-        dr_x = model.dataset.dose_linspace
+        extra_values = [summary.BMD] if summary.BMD >= 0 else []
+        dr_x = model.dataset.dose_linspace(extra_values=extra_values)
         dr_y = clean_array(model.dr_curve(dr_x, params, fixed_lsc))
         critical_ys = clean_array(model.dr_curve(xs, params, fixed_lsc))
         critical_ys[critical_ys <= 0] = constants.BMDS_BLANK_VALUE

--- a/tests/test_pybmds/datasets/test_base.py
+++ b/tests/test_pybmds/datasets/test_base.py
@@ -15,10 +15,16 @@ class TestBaseDatasetFunctionality:
         ds = pybmds.DichotomousDataset(
             doses=[0, 1.96, 5.69, 29.75], ns=[75, 49, 50, 49], incidences=[5, 1, 3, 14]
         )
-        xs = ds.dose_linspace
+        xs = ds.dose_linspace()
         assert xs.min() == pybmds.constants.ZEROISH
         assert xs.max() == 29.75
         assert xs.size == 100
+
+        # add extra values
+        xs = ds.dose_linspace(extra_values=[25, 50], n=10)
+        assert xs.min() == pybmds.constants.ZEROISH
+        assert xs.max() == 50
+        assert xs.size == 10
 
     def test_reporting_metadata(self):
         ds = pybmds.DichotomousDataset(


### PR DESCRIPTION
Update the plotting range to include the BMD, even if it's greater than the maximum dose. The range does not include the BMDU as they can be very large.

![image](https://github.com/user-attachments/assets/f096d69e-34f2-4f2e-90cb-69fa8cab80cd)

Previously, the plot maximum stopped at the maximum dose.
