### PR TITLE
Convert error initial parameter value errors to warnings

### DIFF
--- a/src/pybmds/types/priors.py
+++ b/src/pybmds/types/priors.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from itertools import chain
 from pathlib import Path
 
@@ -142,11 +143,11 @@ class ModelPriors(BaseModel):
         # check values
         for prior in priors:
             if prior.min_value > prior.max_value:
-                raise ValueError(f"Min Value > Max Value ({prior})")
+                warnings.warn(f"Min Value > Max Value ({prior})", stacklevel=2)
             elif prior.initial_value < prior.min_value:
-                raise ValueError(f"Initial Value < Min Value ({prior})")
+                warnings.warn(f"Initial Value < Min Value ({prior})", stacklevel=2)
             elif prior.initial_value > prior.max_value:
-                raise ValueError(f"Initial Value > Max Value ({prior})")
+                warnings.warn(f"Initial Value > Max Value ({prior})", stacklevel=2)
 
         return [prior.numeric_list() for prior in priors]
 

--- a/tests/test_pybmds/types/test_prior.py
+++ b/tests/test_pybmds/types/test_prior.py
@@ -220,5 +220,5 @@ class TestModelPriors:
         ]:
             priors = deepcopy(mock_prior)
             priors.update("a", **settings)
-            with pytest.raises(ValueError, match=message):
+            with pytest.warns(UserWarning, match=message):
                 priors.priors_list()


### PR DESCRIPTION
This PR keeps the new checks introduced in  #94, but raises warnings instead of exceptions. 

Throwing errors caused issues building summary reports on previously completed analyses in BMDS Desktop. The warning will still alert the issue of the possible issues with these parameter settings, but would allow the software to continue to function as it currently does.

Now, code will still execute, but it will complain:

```python
In [1]: import pybmds

In [2]: dataset = pybmds.DichotomousDataset(
   ...:     name="ChemX Nasal Lesion Incidence",
   ...:     dose_name="Concentration",
   ...:     dose_units="ppm",
   ...:     doses=[0, 25, 75, 125, 200],
   ...:     ns=[20, 20, 20, 20, 20],
   ...:     incidences=[0, 1, 7, 15, 19],
   ...: )

In [3]: model = pybmds.models.dichotomous.Logistic(dataset)
   ...: print(model.priors_tbl())
╒═════════════╤═══════════╤═══════╤═══════╕
│ Parameter   │   Initial │   Min │   Max │
╞═════════════╪═══════════╪═══════╪═══════╡
│ a           │         0 │   -18 │    18 │
│ b           │         0 │     0 │   100 │
╘═════════════╧═══════════╧═══════╧═══════╛


In [4]: model.settings.priors.update("b", min_value=10, max_value=1)
   ...: print(model.priors_tbl())
C:\Users\ASHAPIRO\dev\bmds\src\pybmds\models\dichotomous.py:95: UserWarning: Min Value > Max Value (name='b' type=<PriorDistribution.Uniform: 0> initial_value=0.0 stdev=0.0 min_value=10 max_value=1)
  return self.settings.priors.priors_list(degree=degree)
╒═════════════╤═══════════╤═══════╤═══════╕
│ Parameter   │   Initial │   Min │   Max │
╞═════════════╪═══════════╪═══════╪═══════╡
│ a           │         0 │   -18 │    18 │
│ b           │         0 │    10 │     1 │
╘═════════════╧═══════════╧═══════╧═══════╛


In [5]: model.execute()
C:\Users\ASHAPIRO\dev\bmds\src\pybmds\types\priors.py:155: UserWarning: Min Value > Max Value (name='b' type=<PriorDistribution.Uniform: 0> initial_value=0.0 stdev=0.0 min_value=10 max_value=1)
  priors = self.priors_list(degree, dist_type)
C:\Users\ASHAPIRO\dev\bmds\src\pybmds\models\dichotomous.py:95: UserWarning: Min Value > Max Value (name='b' type=<PriorDistribution.Uniform: 0> initial_value=0.0 stdev=0.0 min_value=10 max_value=1)
  return self.settings.priors.priors_list(degree=degree)
Out[5]:
DichotomousResult(...)


```


