### PR TITLE
Remove reporting of burn-in/samples

### DIFF
--- a/docs/source/recipes/nested_dichotomous.ipynb
+++ b/docs/source/recipes/nested_dichotomous.ipynb
@@ -373,7 +373,7 @@
    "id": "9ccbf9ef-87ee-4d25-b583-2696eb30588e",
    "metadata": {},
    "source": [
-    "Model recommendation can be enabled, and if a recommendation can be mode, you can view outputs:"
+    "Model recommendation can be enabled, and if a recommendation is made, you can view outputs:"
    ]
   },
   {

--- a/src/pybmds/types/continuous.py
+++ b/src/pybmds/types/continuous.py
@@ -95,9 +95,6 @@ class ContinuousModelSettings(BaseModel):
         if show_degree:
             data.append(["Degree", self.degree])
 
-        if self.priors.is_bayesian:
-            data.extend((["Samples", self.samples], ["Burn-in", self.burnin]))
-
         return pretty_table(data, "")
 
     @classmethod

--- a/src/pybmds/types/continuous.py
+++ b/src/pybmds/types/continuous.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import NamedTuple, Self
+from typing import Annotated, NamedTuple, Self
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
@@ -45,12 +45,12 @@ class ContinuousModelSettings(BaseModel):
     bmr_type: ContinuousRiskType = ContinuousRiskType.StandardDeviation
     is_increasing: bool | None = None  # if None; autodetect used
     bmr: float = 1.0
-    tail_prob: float = 0.01
+    tail_prob: Annotated[float, Field(gt=0, lt=1)] = 0.01
     disttype: constants.DistType = constants.DistType.normal
-    alpha: float = 0.05
-    samples: int = 0
-    degree: int = 0  # polynomial only
-    burnin: int = 20
+    alpha: Annotated[float, Field(gt=0, lt=1)] = 0.05
+    samples: Annotated[int, Field(ge=10, le=1000)] = 100
+    degree: Annotated[int, Field(ge=0, le=8)] = 0  # polynomial only
+    burnin: Annotated[int, Field(ge=5, le=1000)] = 20
     priors: PriorClass | ModelPriors | None = None  # if None; default used
     name: str = ""  # override model name
 

--- a/src/pybmds/types/dichotomous.py
+++ b/src/pybmds/types/dichotomous.py
@@ -64,9 +64,6 @@ class DichotomousModelSettings(BaseModel):
         if show_degree:
             data.append(["Degree", self.degree])
 
-        if self.priors.is_bayesian:
-            data.extend((["Samples", self.samples], ["Burn-in", self.burnin]))
-
         return pretty_table(data, "")
 
     @classmethod
@@ -77,11 +74,6 @@ class DichotomousModelSettings(BaseModel):
             "Confidence Level (one sided)": unique_items(settings, "confidence_level"),
             "Maximum Multistage Degree": str(max(setting.degree for setting in settings)),
         }
-        if settings[0].priors.is_bayesian:
-            data.update(
-                Samples=unique_items(settings, "samples"),
-                **{"Burn-in": unique_items(settings, "burnin")},
-            )
         return data
 
     def update_record(self, d: dict) -> None:


### PR DESCRIPTION
Because Bayesian models as implemented use the laplace approximation instead of MCMC, remove settings which are not used with how the Bayesian approach is implemented.

Also, add parameter constraints on continuous model settings consistent with dichotomous model settings.