### PR TITLE
Review updates

### DIFF
--- a/src/pybmds/datasets/nested_dichotomous.py
+++ b/src/pybmds/datasets/nested_dichotomous.py
@@ -1,8 +1,8 @@
 import math
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
 import numpy as np
-from pydantic import model_validator
+from pydantic import Field, model_validator
 
 from .. import constants, plotting
 from ..utils import str_list
@@ -136,9 +136,9 @@ class NestedDichotomousDataset(DatasetBase):
 class NestedDichotomousDatasetSchema(DatasetSchemaBase):
     dtype: constants.Dtype = constants.Dtype.NESTED_DICHOTOMOUS
     metadata: DatasetMetadata
-    doses: list[float]
-    litter_ns: list[int]
-    incidences: list[int]
+    doses: list[Annotated[float, Field(ge=0)]]
+    litter_ns: list[Annotated[float, Field(gt=0)]]
+    incidences: list[Annotated[float, Field(ge=0)]]
     litter_covariates: list[float]
 
     MIN_N: ClassVar = 3

--- a/src/pybmds/types/continuous.py
+++ b/src/pybmds/types/continuous.py
@@ -1,3 +1,4 @@
+import warnings
 from enum import IntEnum
 from typing import Annotated, NamedTuple, Self
 
@@ -535,7 +536,10 @@ class ContinuousPlotting(BaseModel):
         extra_values = [summary.BMD] if summary.BMD >= 0 else []
         dr_x = model.dataset.dose_linspace(extra_values=extra_values)
         dr_y = clean_array(model.dr_curve(dr_x, params))
-        critical_ys = clean_array(model.dr_curve(xs, params))
+        with warnings.catch_warnings():
+            # xs may have a nan if a BMDU is not calculated; filter power warnings
+            warnings.filterwarnings("ignore", message=".*invalid value encountered in power.*")
+            critical_ys = clean_array(model.dr_curve(xs, params))
         critical_ys[critical_ys <= 0] = constants.BMDS_BLANK_VALUE
         return cls(
             dr_x=dr_x,

--- a/src/pybmds/types/dichotomous.py
+++ b/src/pybmds/types/dichotomous.py
@@ -1,3 +1,4 @@
+import warnings
 from enum import IntEnum
 from typing import Annotated, NamedTuple, Self
 
@@ -381,7 +382,10 @@ class DichotomousPlotting(BaseModel):
         extra_values = [summary.BMD] if summary.BMD >= 0 else []
         dr_x = model.dataset.dose_linspace(extra_values=extra_values)
         dr_y = clean_array(model.dr_curve(dr_x, params))
-        critical_ys = clean_array(model.dr_curve(xs, params))
+        with warnings.catch_warnings():
+            # xs may have a nan if a BMDU is not calculated; filter power warnings
+            warnings.filterwarnings("ignore", message=".*invalid value encountered in power.*")
+            critical_ys = clean_array(model.dr_curve(xs, params))
         critical_ys[critical_ys <= 0] = constants.BMDS_BLANK_VALUE
         return cls(
             dr_x=dr_x,

--- a/src/pybmds/types/nested_dichotomous.py
+++ b/src/pybmds/types/nested_dichotomous.py
@@ -1,3 +1,4 @@
+import warnings
 from enum import IntEnum
 from random import randrange
 from typing import NamedTuple, Self
@@ -277,7 +278,10 @@ class Plotting(BaseModel):
         extra_values = [summary.BMD] if summary.BMD >= 0 else []
         dr_x = model.dataset.dose_linspace(extra_values=extra_values)
         dr_y = clean_array(model.dr_curve(dr_x, params, fixed_lsc))
-        critical_ys = clean_array(model.dr_curve(xs, params, fixed_lsc))
+        with warnings.catch_warnings():
+            # xs may have a nan if a BMDU is not calculated; filter power warnings
+            warnings.filterwarnings("ignore", message=".*invalid value encountered in power.*")
+            critical_ys = clean_array(model.dr_curve(xs, params, fixed_lsc))
         critical_ys[critical_ys <= 0] = constants.BMDS_BLANK_VALUE
         return cls(
             dr_x=dr_x,

--- a/tests/test_pybmds/models/test_nested_dichotomous.py
+++ b/tests/test_pybmds/models/test_nested_dichotomous.py
@@ -77,6 +77,16 @@ class TestNestedLogistic:
         text = analysis.text()
         assert len(text) > 0
 
+    def test_float_inputs(self, nd_dataset4):
+        # add floating point inputs instead of integer values
+        nd_dataset4.litter_ns[0] += 0.25
+        nd_dataset4.incidences[0] += 0.25
+        nd_dataset4.litter_covariates[0] += 0.25
+        analysis = nested_dichotomous.NestedLogistic(nd_dataset4, settings=dict(bootstrap_seed=1))
+        result = analysis.execute()
+        assert result.has_completed is True
+        assert result.bmd > 0
+
 
 class TestNctr:
     def test_param_names(self, nd_dataset, nd_dataset4):


### PR DESCRIPTION
Updates from internal review.

1. Set minimum values for nested dichotomous dataset and add validation checks via pydantic. We also allow floats in the incidence data instead of just ints, as this is supported by in bmdscore C++:

https://github.com/USEPA/BMDS/blob/5d24d6c95b4d243a9c3dc7bf0440768218510277/src/bmdscore/bmds_helper.h#L322-L325

I also checked in a test run and a test; works fine: 2a3ca73d1e765c9077ee6bd602b915c8da3a3d94



2. Ignore power errors when calculating BMDL/BMD/BMDU values. In some cases the "dose" may be a NaN when calculating these, which can give a warning when calculating. This error is now ignored, but only in the case of estimating y-values for these special values, not with any dose-response calculation.