### PR TITLE
document jupyter nuances in docs

### DIFF
--- a/docs/source/quickstart.ipynb
+++ b/docs/source/quickstart.ipynb
@@ -12,10 +12,6 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import warnings\n",
-    "from IPython.display import display\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\")\n",
     "# tag: remove-cell applied"
    ]
   },

--- a/docs/source/recipes/batch.ipynb
+++ b/docs/source/recipes/batch.ipynb
@@ -15,11 +15,7 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
     "%env TQDM_DISABLE=1\n",
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\")\n",
     "# tag: remove-cell applied"
    ]
   },

--- a/docs/source/recipes/custom-excel-exports.ipynb
+++ b/docs/source/recipes/custom-excel-exports.ipynb
@@ -17,9 +17,6 @@
    "source": [
     "%matplotlib inline\n",
     "%env TQDM_DISABLE=1\n",
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\")\n",
     "# tag: remove-cell applied"
    ]
   },

--- a/docs/source/recipes/dichotomous.ipynb
+++ b/docs/source/recipes/dichotomous.ipynb
@@ -1,22 +1,24 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "f79ba4a8-b4d6-4f65-aead-f71a017b160e",
+   "metadata": {},
+   "source": [
+    "# Dichotomous Data\n",
+    "\n",
+    "When using a jupyter notebook, add this line to make figures appear inline:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "c49af5ec-654c-4a50-8a22-42a275cc38d3",
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\")\n",
-    "from IPython.display import display\n",
-    "# tag: remove-cell applied"
+    "from IPython.display import display"
    ]
   },
   {

--- a/docs/source/recipes/dichotomous.ipynb
+++ b/docs/source/recipes/dichotomous.ipynb
@@ -1,24 +1,19 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "id": "f79ba4a8-b4d6-4f65-aead-f71a017b160e",
-   "metadata": {},
-   "source": [
-    "# Dichotomous Data\n",
-    "\n",
-    "When using a jupyter notebook, add this line to make figures appear inline:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "c49af5ec-654c-4a50-8a22-42a275cc38d3",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "from IPython.display import display"
+    "from IPython.display import display\n",
+    "# tag: remove-cell applied"
    ]
   },
   {
@@ -347,16 +342,16 @@
     "    data = []\n",
     "    for model in session.models:\n",
     "        data.append([\n",
-    "            model.name(), \n",
-    "            model.results.bmdl, \n",
-    "            model.results.bmd, \n",
-    "            model.results.bmdu, \n",
-    "            model.results.gof.p_value, \n",
+    "            model.name(),\n",
+    "            model.results.bmdl,\n",
+    "            model.results.bmd,\n",
+    "            model.results.bmdu,\n",
+    "            model.results.gof.p_value,\n",
     "            model.results.fit.aic\n",
     "        ])\n",
-    "    \n",
+    "\n",
     "    df = pd.DataFrame(\n",
-    "        data=data, \n",
+    "        data=data,\n",
     "        columns=[\"Model\", \"BMDL\", \"BMD\", \"BMDU\", \"P-Value\", \"AIC\"]\n",
     "    )\n",
     "    return df\n",
@@ -409,8 +404,8 @@
    "source": [
     "session.add_default_models(\n",
     "    settings={\n",
-    "        \"bmr\": 0.15, \n",
-    "        \"bmr_type\": pybmds.DichotomousRiskType.AddedRisk, \n",
+    "        \"bmr\": 0.15,\n",
+    "        \"bmr_type\": pybmds.DichotomousRiskType.AddedRisk,\n",
     "        \"alpha\": 0.1\n",
     "    }\n",
     ")"

--- a/docs/source/recipes/dichotomous_ma.ipynb
+++ b/docs/source/recipes/dichotomous_ma.ipynb
@@ -12,8 +12,6 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "# tag: remove-cell applied"
    ]
   },

--- a/docs/source/recipes/index.md
+++ b/docs/source/recipes/index.md
@@ -24,3 +24,32 @@ preparing-datasets
 custom-excel-exports
 using-r
 ```
+
+## Using Jupyter
+
+Recipes are written using [Jupyter](https://jupyter.org/) notebooks for running data-science code in Python. There are many excellent tutorials online describing how to use Jupyter notebooks and this is beyond the scope of `pybmds`. Below are a few tips that may be helpful when copying text from the recipes.
+
+### Rendering figures
+
+The build in plotting functionality of `pybmds` uses [matplotlib](https://matplotlib.org/). To render matplotlib figures within a Jupyter notebooks, add a this line to the top of the notebook[^1]:
+
+```python
+%matplotlib inline
+```
+
+After running this cell, matplotlib figures will appear inline after a cell is executed, if it is the final output in a cell.
+
+[^1]: A Stack Overflow [summary](https://stackoverflow.com/q/43027980/906385) of the purpose of `%matplotlib inline`
+
+### Display extra cell output
+
+By default, notebook cells only display the last output of the code that is executed in them, and anything that you `print` to the screen. You can also `display`[^2] content at any time in a cell by importing the display method. This will allow you to show plots or text in the middle of loops, for example:
+
+```python
+from IPython.display import display
+
+display(...)
+```
+
+[^2]: For more information on displaying outputs; see the IPython [documentation](https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.display).
+

--- a/docs/source/recipes/index.md
+++ b/docs/source/recipes/index.md
@@ -31,7 +31,7 @@ Recipes are written using [Jupyter](https://jupyter.org/) notebooks. There are m
 
 ### Rendering figures
 
-The plotting functionality of `pybmds` uses the [matplotlib](https://matplotlib.org/) package to generate figures. To render matplotlib figures within a Jupyter notebook, add this "magic function" to a cell at the top of the notebook, and execute the cell to enable inline plot rendering:
+The built-in plotting functionality of `pybmds` uses [matplotlib](https://matplotlib.org/). To render matplotlib figures within a Jupyter notebook, add this line to the top of the notebook:
 
 ```python
 %matplotlib inline

--- a/docs/source/recipes/index.md
+++ b/docs/source/recipes/index.md
@@ -25,25 +25,23 @@ custom-excel-exports
 using-r
 ```
 
-## Using Jupyter
+## Jupyter Notebooks
 
-Recipes are written using [Jupyter](https://jupyter.org/) notebooks for running data-science code in Python. There are many excellent tutorials online describing how to use Jupyter notebooks and this is beyond the scope of `pybmds`. Below are a few tips that may be helpful when copying text from the recipes.
+Recipes are written using [Jupyter](https://jupyter.org/) notebooks. There are many excellent tutorials online describing how to use Jupyter notebooks and this is beyond the scope of `pybmds`. However, a few tips are described below for new Jupyter users.
 
 ### Rendering figures
 
-The build in plotting functionality of `pybmds` uses [matplotlib](https://matplotlib.org/). To render matplotlib figures within a Jupyter notebooks, add a this line to the top of the notebook[^1]:
+The plotting functionality of `pybmds` uses the [matplotlib](https://matplotlib.org/) package to generate figures. To render matplotlib figures within a Jupyter notebook, add this "magic function" to a cell at the top of the notebook, and execute the cell to enable inline plot rendering:
 
 ```python
 %matplotlib inline
 ```
 
-After running this cell, matplotlib figures will appear inline after a cell is executed, if it is the final output in a cell.
+After running this cell, matplotlib figures will appear inline after execution, if it is the final output in a cell. For more information, see this [summary](https://stackoverflow.com/q/43027980/906385) from Stack Overflow.
 
-[^1]: A Stack Overflow [summary](https://stackoverflow.com/q/43027980/906385) of the purpose of `%matplotlib inline`
+### Displaying extra output
 
-### Display extra cell output
-
-By default, notebook cells only display the last output of the code that is executed in them, and anything that you `print` to the screen. You can also `display`[^2] content at any time in a cell by importing the display method. This will allow you to show plots or text in the middle of loops, for example:
+By default, notebook cells only display the last output of the code that is executed in them, and anything that is printed to standard out (for example anything using the `print()` function). You can also display content at any time in a cell by using the [display](https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.display) method. This will allow you to show plots or text in the middle of loops, or show multiple outputs from a single cell. We utilize this function in some recipes.
 
 ```python
 from IPython.display import display
@@ -51,5 +49,4 @@ from IPython.display import display
 display(...)
 ```
 
-[^2]: For more information on displaying outputs; see the IPython [documentation](https://ipython.readthedocs.io/en/stable/api/generated/IPython.display.html#IPython.display.display).
-
+Anything that is passed to this function will be shown after the cell is executed.

--- a/docs/source/recipes/multitumor.ipynb
+++ b/docs/source/recipes/multitumor.ipynb
@@ -16,9 +16,6 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import warnings\n",
-    "\n",
-    "warnings.filterwarnings(\"ignore\")\n",
     "from IPython.display import display\n",
     "# tag: remove-cell applied"
    ]

--- a/docs/source/recipes/nested_dichotomous.ipynb
+++ b/docs/source/recipes/nested_dichotomous.ipynb
@@ -34,8 +34,6 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "# tag: remove-cell applied"
    ]
   },

--- a/docs/source/recipes/preparing-datasets.ipynb
+++ b/docs/source/recipes/preparing-datasets.ipynb
@@ -17,8 +17,6 @@
    "source": [
     "%matplotlib inline\n",
     "%env TQDM_DISABLE=1\n",
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "# tag: remove-cell applied"
    ]
   },


### PR DESCRIPTION
We received some feedback that novice (python) users couldn't view plots in jupyter, which is a common "gotcha" for people new to python/jupyter, and were encouraged to add details to our documentation. I'm exploring different ways to implement this information, and have 3 options.

---

**Option A**: add to the top of each recipe.  I do not prefer this as it takes the focus away from pybmds and into how to use jupyter:

![image](https://github.com/user-attachments/assets/5966adc0-8859-40d6-9f08-30a88a3ed7b7)

**Option B**: add a new section to the recipes that describes jupyter nuances:
https://github.com/USEPA/BMDS/blob/87e96d9f1d8855eb1a2f1916d77614eb2322c79d/docs/source/recipes/index.md?plain=1#L28-L54

**Option C**: don't make changes? It's nice to have in one place, but this isn't really the focus of pybmds, and you can find it in other places a simple google query away. I dont want to house knowledge for other external packages in our software, but then again, I'm not sure our users have the general python proficiency to know what to google (but, this is a python package, so we can assume they have some proficiency). Not sure what the appropriate level of detail is.

