### PR TITLE
update CI environments to Python 3.13

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,7 +38,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   build:
     name: Build Documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
       - name: Install dependencies
         run: |
@@ -38,7 +38,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: Build Documentation
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   pybmds:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     env:
       generateDocx: ${{ inputs.generateDocx }}
     steps:
@@ -82,7 +82,7 @@ jobs:
           retention-days: 14
 
   bmdscore:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   pybmds:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       generateDocx: ${{ inputs.generateDocx }}
     steps:
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
       - name: Install dependencies
         run: |
@@ -82,7 +82,7 @@ jobs:
           retention-days: 14
 
   bmdscore:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -12,13 +12,13 @@ concurrency:
 
 jobs:
   pybmds:
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - uses: actions/checkout@v4
       - name: set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: pip
       - name: Set dependency path
         shell: bash

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   pybmds:
-    runs-on: windows-2025
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - name: set up Python

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-2025, macos-15]
+        os: [ubuntu-22.04, windows-2022, macos-14]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-14]
+        os: [ubuntu-24.04, windows-2025, macos-15]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: Show wheels that will be built
         run: |
           python -m pip install cibuildwheel==2.21.1
@@ -36,7 +36,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   merge_wheels:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: build_wheels
     steps:
       - name: Merge Artifacts

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -36,7 +36,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   merge_wheels:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: build_wheels
     steps:
       - name: Merge Artifacts

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
   apt_packages:
     # copied from `tools/linux_ci_setup.sh`
     - automake

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 # https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
 build:
-  os: ubuntu-24.04
+  os: ubuntu-22.04
   tools:
     python: "3.13"
   apt_packages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,6 @@ python_files = ["test_*.py"]
 [tool.ruff]
 exclude = ["docs"]
 line-length = 100
-target-version = "py311"
 lint.select = ["F", "E", "W", "I", "UP", "S", "B", "T20", "ERA", "NPY", "RUF", "PTH"]
 lint.ignore = ["E501"]
 lint.isort.known-first-party = ["pybmds"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ python_files = ["test_*.py"]
 [tool.ruff]
 exclude = ["docs"]
 line-length = 100
+target-version = "py311"
 lint.select = ["F", "E", "W", "I", "UP", "S", "B", "T20", "ERA", "NPY", "RUF", "PTH"]
 lint.ignore = ["E501"]
 lint.isort.known-first-party = ["pybmds"]


### PR DESCRIPTION
Update developer environment to Python 3.13, as well as GitHub actions. We still continue to support older versions of Python until 3.11, which is expected to end of life in 2027.