### PR TITLE
make boundary AIC penalty configurable

### DIFF
--- a/src/bmdscore/bmds_helper.cpp
+++ b/src/bmdscore/bmds_helper.cpp
@@ -77,13 +77,13 @@ void calcDichoAIC(
 
   estParmCount = anal->parms - bounded;
 
+  if (penalizeAIC){
+    estParmCount -= bounded;
+  }
+
   // if freq then model_df should be rounded to nearest whole number
   if (freqModel) estParmCount = round(estParmCount);
   BMDSres->AIC = 2 * (res->max + estParmCount);
-
-  if (!penalizeAIC) {
-    BMDSres->AIC += 2*bounded;
-  }
 
   free(lowerBound);
   free(upperBound);
@@ -125,7 +125,6 @@ void calcContAIC(
 
   BMDSres->AIC = 2 * (res->max + estParmCount);
 
-  //               //    BMDSres->AIC = -9998.0;
   free(lowerBound);
   free(upperBound);
 }

--- a/src/bmdscore/bmds_helper.cpp
+++ b/src/bmdscore/bmds_helper.cpp
@@ -77,7 +77,7 @@ void calcDichoAIC(
 
   estParmCount = anal->parms - bounded;
 
-  if (penalizeAIC){
+  if (penalizeAIC) {
     estParmCount -= bounded;
   }
 
@@ -117,7 +117,7 @@ void calcContAIC(
   int bounded = checkForBoundedParms(res->nparms, res->parms, lowerBound, upperBound, BMDSres);
 
   double estParmCount = res->model_df;
-  if (penalizeAIC){
+  if (penalizeAIC) {
     estParmCount -= bounded;
   }
   // if freq then model_df should be rounded to nearest whole number
@@ -129,10 +129,11 @@ void calcContAIC(
   free(upperBound);
 }
 
-double calcNestedAIC( double fitted_LL, double fitted_df, double red_df, int numBounded, bool penalizeAIC){
-
+double calcNestedAIC(
+    double fitted_LL, double fitted_df, double red_df, int numBounded, bool penalizeAIC
+) {
   double AIC;
-  if (penalizeAIC){
+  if (penalizeAIC) {
     AIC = -2 * fitted_LL + 2 * (1.0 + red_df - fitted_df);
   } else {
     AIC = -2 * fitted_LL + 2 * (1.0 + red_df - (fitted_df + numBounded));
@@ -1360,7 +1361,6 @@ void BMDS_ENTRY_API __stdcall runBMDSContAnalysis(
     struct BMDS_results *bmdsRes, struct continuous_AOD *aod, struct continuous_GOF *gof,
     bool *detectAdvDir, bool *restricted, bool *penalizeAIC
 ) {
-  
   bmdsRes->BMD = BMDS_MISSING;
   bmdsRes->BMDL = BMDS_MISSING;
   bmdsRes->BMDU = BMDS_MISSING;
@@ -2317,7 +2317,6 @@ void convertToPythonContRes(
 void BMDS_ENTRY_API __stdcall pythonBMDSDicho(
     struct python_dichotomous_analysis *pyAnal, struct python_dichotomous_model_result *pyRes
 ) {
-
   // 1st convert from python struct
   dichotomous_analysis anal;
   anal.Y = new double[pyAnal->n];
@@ -2332,8 +2331,9 @@ void BMDS_ENTRY_API __stdcall pythonBMDSDicho(
   res.bmd_dist = new double[pyRes->dist_numE * 2];
   convertFromPythonDichoRes(&res, pyRes);
 
-
-  runBMDSDichoAnalysis(&anal, &res, &pyRes->gof, &pyRes->bmdsRes, &pyRes->aod, &pyAnal->penalizeAIC);
+  runBMDSDichoAnalysis(
+      &anal, &res, &pyRes->gof, &pyRes->bmdsRes, &pyRes->aod, &pyAnal->penalizeAIC
+  );
 
   convertToPythonDichoRes(&res, pyRes);
 }
@@ -3294,7 +3294,7 @@ void BMDS_ENTRY_API __stdcall pythonBMDSNested(
       pyRes->nparms, &pyRes->parms[0], &lowerBound[0], &upperBound[0], &pyRes->bmdsRes
   );
 
-  //numBounded = 0;
+  // numBounded = 0;
 
   // remove rows and columns of vcv that correspond to bounded parms
   for (int i = 0; i < pyRes->nparms; i++) {
@@ -3410,8 +3410,8 @@ void BMDS_ENTRY_API __stdcall pythonBMDSNested(
   anovaVec.push_back(fittedAnova);
   anovaVec.push_back(redAnova);
 
-
-  pyRes->bmdsRes.AIC = calcNestedAIC( fittedAnova.LL, fittedAnova.df, redAnova.df, numBounded, pyAnal->penalizeAIC);
+  pyRes->bmdsRes.AIC =
+      calcNestedAIC(fittedAnova.LL, fittedAnova.df, redAnova.df, numBounded, pyAnal->penalizeAIC);
 
   pyRes->model_df = fittedAnova.df;
 

--- a/src/bmdscore/bmds_helper.cpp
+++ b/src/bmdscore/bmds_helper.cpp
@@ -53,7 +53,7 @@ int checkForBoundedParms(
 
 void calcDichoAIC(
     struct dichotomous_analysis *anal, struct dichotomous_model_result *res,
-    struct BMDS_results *BMDSres, double estParmCount, bool penalizeAIC
+    struct BMDS_results *BMDSres, bool penalizeAIC
 ) {
   bool freqModel = anal->prior[0] == 0;
 
@@ -75,7 +75,7 @@ void calcDichoAIC(
 
   int bounded = checkForBoundedParms(anal->parms, res->parms, lowerBound, upperBound, BMDSres);
 
-  estParmCount = anal->parms - bounded;
+  double estParmCount = anal->parms;
 
   if (penalizeAIC) {
     estParmCount -= bounded;
@@ -162,7 +162,7 @@ double findQuantileVals(double *quant, double *val, int arrSize, double target) 
 
 void collect_dicho_bmd_values(
     struct dichotomous_analysis *anal, struct dichotomous_model_result *res,
-    struct BMDS_results *BMDSres, double estParmCount, bool penalizeAIC
+    struct BMDS_results *BMDSres, bool penalizeAIC
 ) {
   int distSize = res->dist_numE * 2;
 
@@ -176,7 +176,7 @@ void collect_dicho_bmd_values(
     quant[i - distSize / 2] = res->bmd_dist[i];
   }
 
-  calcDichoAIC(anal, res, BMDSres, estParmCount, penalizeAIC);
+  calcDichoAIC(anal, res, BMDSres, penalizeAIC);
   BMDSres->BMD = findQuantileVals(quant, val, distSize / 2, 0.50);
   BMDSres->BMDL = findQuantileVals(quant, val, distSize / 2, anal->alpha);
   BMDSres->BMDU = findQuantileVals(quant, val, distSize / 2, 1.0 - anal->alpha);
@@ -1171,7 +1171,7 @@ void BMDS_ENTRY_API __stdcall runBMDSDichoAnalysis(
 
   double estParmCount = 0;
 
-  collect_dicho_bmd_values(anal, res, bmdsRes, estParmCount, *penalizeAIC);
+  collect_dicho_bmd_values(anal, res, bmdsRes, *penalizeAIC);
 
   // incorporate affect of bounded parameters
   int bounded = 0;

--- a/src/bmdscore/bmds_helper.cpp
+++ b/src/bmdscore/bmds_helper.cpp
@@ -129,6 +129,18 @@ void calcContAIC(
   free(upperBound);
 }
 
+double calcNestedAIC( double fitted_LL, double fitted_df, double red_df, int numBounded, bool penalizeAIC){
+
+  double AIC;
+  if (penalizeAIC){
+    AIC = -2 * fitted_LL + 2 * (1.0 + red_df - fitted_df);
+  } else {
+    AIC = -2 * fitted_LL + 2 * (1.0 + red_df - (fitted_df + numBounded));
+  }
+
+  return AIC;
+}
+
 double findQuantileVals(double *quant, double *val, int arrSize, double target) {
   double retVal = BMDS_MISSING;
 
@@ -3398,11 +3410,8 @@ void BMDS_ENTRY_API __stdcall pythonBMDSNested(
   anovaVec.push_back(fittedAnova);
   anovaVec.push_back(redAnova);
 
-  if (pyAnal->penalizeAIC){
-    pyRes->bmdsRes.AIC = -2 * fittedAnova.LL + 2 * (1.0 + redAnova.df - fittedAnova.df);
-  } else {
-    pyRes->bmdsRes.AIC = -2 * fittedAnova.LL + 2 * (1.0 + redAnova.df - (fittedAnova.df + numBounded));
-  }
+
+  pyRes->bmdsRes.AIC = calcNestedAIC( fittedAnova.LL, fittedAnova.df, redAnova.df, numBounded, pyAnal->penalizeAIC);
 
   pyRes->model_df = fittedAnova.df;
 

--- a/src/bmdscore/bmds_helper.cpp
+++ b/src/bmdscore/bmds_helper.cpp
@@ -3294,8 +3294,6 @@ void BMDS_ENTRY_API __stdcall pythonBMDSNested(
       pyRes->nparms, &pyRes->parms[0], &lowerBound[0], &upperBound[0], &pyRes->bmdsRes
   );
 
-  // numBounded = 0;
-
   // remove rows and columns of vcv that correspond to bounded parms
   for (int i = 0; i < pyRes->nparms; i++) {
     if (pyRes->bmdsRes.bounded[i]) {

--- a/src/bmdscore/bmds_helper.h
+++ b/src/bmdscore/bmds_helper.h
@@ -298,7 +298,6 @@ struct python_multitumor_analysis {
   int prior_cols;  // colunns in the prior
   std::vector<int>
       degree;  // degree of selected polynomial used for each ind multistage (size ndatasets)
-  bool penalizeAIC;  //whether to penalize the AIC by counting parameters that hit a bound
 };
 
 struct python_multitumor_result {
@@ -464,6 +463,16 @@ void collect_dichoMA_bmd_values(
 void collect_cont_bmd_values(
     struct continuous_analysis *anal, struct continuous_model_result *res,
     struct BMDS_results *BMDres
+);
+
+void calcDichoAIC(
+    struct dichotomous_analysis *anal, struct dichotomous_model_result *res,
+    struct BMDS_results *BMDSres, double estParmCount, bool penalizeAIC
+);
+
+void calcContAIC(
+    struct continuous_analysis *anal, struct continuous_model_result *res,
+    struct BMDS_results *BMDSres, bool penalizeAIC
 );
 
 void clean_dicho_results(

--- a/src/bmdscore/bmds_helper.h
+++ b/src/bmdscore/bmds_helper.h
@@ -189,13 +189,13 @@ struct python_dichotomous_analysis {
   std::vector<double> prior;    // a column order matrix (parms x prior_cols)
   int BMD_type;                 // 1 = extra ; added otherwise
   double BMR;
-  double alpha;    // alpha of the analysis
-  int degree;      // degree of polynomial used only  multistage
-  int samples;     // number of MCMC samples.
-  int burnin;      // size of burin
-  int parms;       // number of parameters in the model
-  int prior_cols;  // colunns in the prior
-  bool penalizeAIC;  //whether to penalize the AIC by counting parameters that hit a bound
+  double alpha;      // alpha of the analysis
+  int degree;        // degree of polynomial used only  multistage
+  int samples;       // number of MCMC samples.
+  int burnin;        // size of burin
+  int parms;         // number of parameters in the model
+  int prior_cols;    // colunns in the prior
+  bool penalizeAIC;  // whether to penalize the AIC by counting parameters that hit a bound
 };
 
 struct python_dichotomous_model_result {
@@ -264,7 +264,7 @@ struct python_continuous_analysis {
   int transform_dose;  // Use the arc-sin-hyperbolic inverse to transform dose.
   bool restricted;
   bool detectAdvDir;
-  bool penalizeAIC;  //whether to penalize the AIC by counting parameters that hit a bound
+  bool penalizeAIC;  // whether to penalize the AIC by counting parameters that hit a bound
 };
 
 struct python_continuous_model_result {
@@ -334,10 +334,10 @@ struct python_nested_analysis {
   int prior_cols;
   double BMR;
   double alpha;
-  int numBootRuns;  // number of bootstrap run
-  int iterations;   // number of iterations per run
-  long seed;        // -9999 = automatic;  seed value otherwise
-  bool penalizeAIC;  //whether to penalize the AIC by counting parameters that hit a bound
+  int numBootRuns;   // number of bootstrap run
+  int iterations;    // number of iterations per run
+  long seed;         // -9999 = automatic;  seed value otherwise
+  bool penalizeAIC;  // whether to penalize the AIC by counting parameters that hit a bound
 };
 
 struct python_nested_result {
@@ -475,7 +475,9 @@ void calcContAIC(
     struct BMDS_results *BMDSres, bool penalizeAIC
 );
 
-double calcNestedAIC( double fitted_LL, double fitted_df, double red_df, int numBounded, bool penalizeAIC);
+double calcNestedAIC(
+    double fitted_LL, double fitted_df, double red_df, int numBounded, bool penalizeAIC
+);
 
 void clean_dicho_results(
     struct dichotomous_model_result *res, struct dichotomous_GOF *gof, struct BMDS_results *bmdsRes,

--- a/src/bmdscore/bmds_helper.h
+++ b/src/bmdscore/bmds_helper.h
@@ -454,7 +454,7 @@ void calc_dichoAOD(
 
 void collect_dicho_bmd_values(
     struct dichotomous_analysis *anal, struct dichotomous_model_result *res,
-    struct BMDS_results *BMDres, double estParmCount
+    struct BMDS_results *BMDres
 );
 void collect_dichoMA_bmd_values(
     struct dichotomousMA_analysis *anal, struct dichotomousMA_result *res,
@@ -467,7 +467,7 @@ void collect_cont_bmd_values(
 
 void calcDichoAIC(
     struct dichotomous_analysis *anal, struct dichotomous_model_result *res,
-    struct BMDS_results *BMDSres, double estParmCount, bool penalizeAIC
+    struct BMDS_results *BMDSres, bool penalizeAIC
 );
 
 void calcContAIC(

--- a/src/bmdscore/bmds_helper.h
+++ b/src/bmdscore/bmds_helper.h
@@ -475,6 +475,8 @@ void calcContAIC(
     struct BMDS_results *BMDSres, bool penalizeAIC
 );
 
+double calcNestedAIC( double fitted_LL, double fitted_df, double red_df, int numBounded, bool penalizeAIC);
+
 void clean_dicho_results(
     struct dichotomous_model_result *res, struct dichotomous_GOF *gof, struct BMDS_results *bmdsRes,
     struct dicho_AOD *aod

--- a/src/bmdscore/bmds_helper.h
+++ b/src/bmdscore/bmds_helper.h
@@ -195,6 +195,7 @@ struct python_dichotomous_analysis {
   int burnin;      // size of burin
   int parms;       // number of parameters in the model
   int prior_cols;  // colunns in the prior
+  bool penalizeAIC;  //whether to penalize the AIC by counting parameters that hit a bound
 };
 
 struct python_dichotomous_model_result {
@@ -263,6 +264,7 @@ struct python_continuous_analysis {
   int transform_dose;  // Use the arc-sin-hyperbolic inverse to transform dose.
   bool restricted;
   bool detectAdvDir;
+  bool penalizeAIC;  //whether to penalize the AIC by counting parameters that hit a bound
 };
 
 struct python_continuous_model_result {
@@ -296,6 +298,7 @@ struct python_multitumor_analysis {
   int prior_cols;  // colunns in the prior
   std::vector<int>
       degree;  // degree of selected polynomial used for each ind multistage (size ndatasets)
+  bool penalizeAIC;  //whether to penalize the AIC by counting parameters that hit a bound
 };
 
 struct python_multitumor_result {
@@ -335,6 +338,7 @@ struct python_nested_analysis {
   int numBootRuns;  // number of bootstrap run
   int iterations;   // number of iterations per run
   long seed;        // -9999 = automatic;  seed value otherwise
+  bool penalizeAIC;  //whether to penalize the AIC by counting parameters that hit a bound
 };
 
 struct python_nested_result {
@@ -644,13 +648,14 @@ void SortNestedData(
 
 void BMDS_ENTRY_API __stdcall runBMDSDichoAnalysis(
     struct dichotomous_analysis *anal, struct dichotomous_model_result *res,
-    struct dichotomous_GOF *gof, struct BMDS_results *bmdsRes, struct dicho_AOD *aod
+    struct dichotomous_GOF *gof, struct BMDS_results *bmdsRes, struct dicho_AOD *aod,
+    bool *penalizeAIC
 );
 
 void BMDS_ENTRY_API __stdcall runBMDSContAnalysis(
     struct continuous_analysis *anal, struct continuous_model_result *res,
     struct BMDS_results *bmdsRes, struct continuous_AOD *aod, struct continuous_GOF *gof,
-    bool *detectAdvDir, bool *restricted
+    bool *detectAdvDir, bool *restricted, bool *penalizeAIC
 );
 
 void BMDS_ENTRY_API __stdcall runBMDSDichoMA(

--- a/src/pybmds/models/continuous.py
+++ b/src/pybmds/models/continuous.py
@@ -66,7 +66,7 @@ class BmdModelContinuous(BmdModel):
             samples=self.settings.samples,
             burnin=self.settings.burnin,
             degree=self.settings.degree,
-            boundary_param_penalize_aic=self.settings.boundary_param_penalize_aic,
+            penalize_aic_on_boundary=self.settings.penalize_aic_on_boundary,
         )
 
     def execute(self) -> ContinuousResult:

--- a/src/pybmds/models/continuous.py
+++ b/src/pybmds/models/continuous.py
@@ -66,6 +66,7 @@ class BmdModelContinuous(BmdModel):
             samples=self.settings.samples,
             burnin=self.settings.burnin,
             degree=self.settings.degree,
+            boundary_param_penalize_aic=self.settings.boundary_param_penalize_aic,
         )
 
     def execute(self) -> ContinuousResult:

--- a/src/pybmds/models/dichotomous.py
+++ b/src/pybmds/models/dichotomous.py
@@ -48,7 +48,7 @@ class BmdModelDichotomous(BmdModel):
             degree=self.settings.degree,
             samples=self.settings.samples,
             burnin=self.settings.burnin,
-            boundary_param_penalize_aic=self.settings.boundary_param_penalize_aic,
+            penalize_aic_on_boundary=self.settings.penalize_aic_on_boundary,
         )
 
     def execute(self, slope_factor: bool = False) -> DichotomousResult:

--- a/src/pybmds/models/dichotomous.py
+++ b/src/pybmds/models/dichotomous.py
@@ -48,6 +48,7 @@ class BmdModelDichotomous(BmdModel):
             degree=self.settings.degree,
             samples=self.settings.samples,
             burnin=self.settings.burnin,
+            boundary_param_penalize_aic=self.settings.boundary_param_penalize_aic,
         )
 
     def execute(self, slope_factor: bool = False) -> DichotomousResult:

--- a/src/pybmds/types/continuous.py
+++ b/src/pybmds/types/continuous.py
@@ -43,6 +43,7 @@ _bmr_text_map = {
 
 
 class ContinuousModelSettings(BaseModel):
+    name: str = ""  # override model name
     bmr_type: ContinuousRiskType = ContinuousRiskType.StandardDeviation
     is_increasing: bool | None = None  # if None; autodetect used
     bmr: float = 1.0
@@ -53,7 +54,7 @@ class ContinuousModelSettings(BaseModel):
     degree: Annotated[int, Field(ge=0, le=8)] = 0  # polynomial only
     burnin: Annotated[int, Field(ge=5, le=1000)] = 20
     priors: PriorClass | ModelPriors | None = None  # if None; default used
-    name: str = ""  # override model name
+    boundary_param_penalize_aic: bool = True
 
     model_config = ConfigDict(extra="forbid")
 
@@ -147,6 +148,8 @@ class ContinuousAnalysis(BaseModel):
     samples: int
     burnin: int
     degree: int
+    boundary_param_penalize_aic: bool
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
@@ -181,6 +184,7 @@ class ContinuousAnalysis(BaseModel):
         analysis.degree = self.degree
         analysis.disttype = self.disttype.value
         analysis.alpha = self.alpha
+        analysis.penalizeAIC = self.boundary_param_penalize_aic
 
         # these 3 variables are related; if setting direction; set others to False
         analysis.isIncreasing = self.is_increasing

--- a/src/pybmds/types/continuous.py
+++ b/src/pybmds/types/continuous.py
@@ -54,7 +54,7 @@ class ContinuousModelSettings(BaseModel):
     degree: Annotated[int, Field(ge=0, le=8)] = 0  # polynomial only
     burnin: Annotated[int, Field(ge=5, le=1000)] = 20
     priors: PriorClass | ModelPriors | None = None  # if None; default used
-    boundary_param_penalize_aic: bool = True
+    penalize_aic_on_boundary: bool = True
 
     model_config = ConfigDict(extra="forbid")
 
@@ -148,7 +148,7 @@ class ContinuousAnalysis(BaseModel):
     samples: int
     burnin: int
     degree: int
-    boundary_param_penalize_aic: bool
+    penalize_aic_on_boundary: bool
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -184,7 +184,7 @@ class ContinuousAnalysis(BaseModel):
         analysis.degree = self.degree
         analysis.disttype = self.disttype.value
         analysis.alpha = self.alpha
-        analysis.penalizeAIC = self.boundary_param_penalize_aic
+        analysis.penalizeAIC = self.penalize_aic_on_boundary
 
         # these 3 variables are related; if setting direction; set others to False
         analysis.isIncreasing = self.is_increasing

--- a/src/pybmds/types/dichotomous.py
+++ b/src/pybmds/types/dichotomous.py
@@ -32,6 +32,7 @@ _bmr_text_map = {
 
 
 class DichotomousModelSettings(BaseModel):
+    name: str = ""  # override model name
     bmr: Annotated[float, Field(gt=0)] = 0.1
     alpha: Annotated[float, Field(gt=0, lt=1)] = 0.05
     bmr_type: DichotomousRiskType = DichotomousRiskType.ExtraRisk
@@ -39,7 +40,7 @@ class DichotomousModelSettings(BaseModel):
     samples: Annotated[int, Field(ge=10, le=1000)] = 100
     burnin: Annotated[int, Field(ge=5, le=1000)] = 20
     priors: PriorClass | ModelPriors | None = None  # if None; default used
-    name: str = ""  # override model name
+    boundary_param_penalize_aic: bool = True
 
     model_config = ConfigDict(extra="forbid")
 
@@ -104,6 +105,7 @@ class DichotomousAnalysis(BaseModel):
     degree: int
     samples: int
     burnin: int
+    boundary_param_penalize_aic: bool
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -137,6 +139,7 @@ class DichotomousAnalysis(BaseModel):
         analysis.burnin = self.burnin
         analysis.parms = self.num_params
         analysis.prior_cols = constants.NUM_PRIOR_COLS
+        analysis.penalizeAIC = self.boundary_param_penalize_aic
         return analysis
 
     def to_cpp_result(self, analysis) -> bmdscore.python_dichotomous_model_result:

--- a/src/pybmds/types/dichotomous.py
+++ b/src/pybmds/types/dichotomous.py
@@ -40,7 +40,7 @@ class DichotomousModelSettings(BaseModel):
     samples: Annotated[int, Field(ge=10, le=1000)] = 100
     burnin: Annotated[int, Field(ge=5, le=1000)] = 20
     priors: PriorClass | ModelPriors | None = None  # if None; default used
-    boundary_param_penalize_aic: bool = True
+    penalize_aic_on_boundary: bool = True
 
     model_config = ConfigDict(extra="forbid")
 
@@ -105,7 +105,7 @@ class DichotomousAnalysis(BaseModel):
     degree: int
     samples: int
     burnin: int
-    boundary_param_penalize_aic: bool
+    penalize_aic_on_boundary: bool
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -139,7 +139,7 @@ class DichotomousAnalysis(BaseModel):
         analysis.burnin = self.burnin
         analysis.parms = self.num_params
         analysis.prior_cols = constants.NUM_PRIOR_COLS
-        analysis.penalizeAIC = self.boundary_param_penalize_aic
+        analysis.penalizeAIC = self.penalize_aic_on_boundary
         return analysis
 
     def to_cpp_result(self, analysis) -> bmdscore.python_dichotomous_model_result:

--- a/src/pybmds/types/nested_dichotomous.py
+++ b/src/pybmds/types/nested_dichotomous.py
@@ -65,7 +65,7 @@ class NestedDichotomousModelSettings(BaseModel):
     bootstrap_iterations: int = Field(default=1000, ge=10, le=1_000_000)
     bootstrap_seed: int = Field(default_factory=lambda: randrange(0, 1_000), ge=0, le=1_000)  # noqa: S311
     bootstrap_n: int = Field(default=3, ge=1, le=10)
-    boundary_param_penalize_aic: bool = True
+    penalize_aic_on_boundary: bool = True
     priors: PriorClass | ModelPriors | None = None  # if None; default used
 
     model_config = ConfigDict(extra="forbid")
@@ -161,7 +161,7 @@ class NestedDichotomousAnalysis(NamedTuple):
         analysis.numBootRuns = settings.bootstrap_n
         analysis.iterations = settings.bootstrap_iterations
         analysis.seed = settings.bootstrap_seed
-        analysis.penalizeAIC = settings.boundary_param_penalize_aic
+        analysis.penalizeAIC = settings.penalize_aic_on_boundary
 
         result = bmdscore.python_nested_result()
         result.nparms = analysis.parms

--- a/src/pybmds/types/nested_dichotomous.py
+++ b/src/pybmds/types/nested_dichotomous.py
@@ -55,6 +55,7 @@ _bmr_text_map = {
 
 
 class NestedDichotomousModelSettings(BaseModel):
+    name: str = ""  # override model name
     bmr_type: RiskType = RiskType.ExtraRisk
     bmr: float = Field(default=0.1, gt=0)
     alpha: float = Field(default=0.05, gt=0, lt=1)
@@ -64,7 +65,7 @@ class NestedDichotomousModelSettings(BaseModel):
     bootstrap_iterations: int = Field(default=1000, ge=10, le=1_000_000)
     bootstrap_seed: int = Field(default_factory=lambda: randrange(0, 1_000), ge=0, le=1_000)  # noqa: S311
     bootstrap_n: int = Field(default=3, ge=1, le=10)
-    name: str = ""  # override model name
+    boundary_param_penalize_aic: bool = True
     priors: PriorClass | ModelPriors | None = None  # if None; default used
 
     model_config = ConfigDict(extra="forbid")
@@ -160,6 +161,7 @@ class NestedDichotomousAnalysis(NamedTuple):
         analysis.numBootRuns = settings.bootstrap_n
         analysis.iterations = settings.bootstrap_iterations
         analysis.seed = settings.bootstrap_seed
+        analysis.penalizeAIC = settings.boundary_param_penalize_aic
 
         result = bmdscore.python_nested_result()
         result.nparms = analysis.parms

--- a/src/pybmdscpp/main.cpp
+++ b/src/pybmdscpp/main.cpp
@@ -183,7 +183,8 @@ PYBIND11_MODULE(bmdscore, m) {
       .def_readwrite("samples", &python_dichotomous_analysis::samples)
       .def_readwrite("burnin", &python_dichotomous_analysis::burnin)
       .def_readwrite("parms", &python_dichotomous_analysis::parms)
-      .def_readwrite("prior_cols", &python_dichotomous_analysis::prior_cols);
+      .def_readwrite("prior_cols", &python_dichotomous_analysis::prior_cols)
+      .def_readwrite("penalizeAIC", &python_dichotomous_analysis::penalizeAIC);
 
   py::class_<python_dichotomous_model_result>(m, "python_dichotomous_model_result")
       .def(py::init<>())
@@ -248,7 +249,8 @@ PYBIND11_MODULE(bmdscore, m) {
       .def_readwrite("prior_cols", &python_continuous_analysis::prior_cols)
       .def_readwrite("transform_dose", &python_continuous_analysis::transform_dose)
       .def_readwrite("restricted", &python_continuous_analysis::restricted)
-      .def_readwrite("detectAdvDir", &python_continuous_analysis::detectAdvDir);
+      .def_readwrite("detectAdvDir", &python_continuous_analysis::detectAdvDir)
+      .def_readwrite("penalizeAIC", &python_continuous_analysis::penalizeAIC);
 
   py::class_<python_continuous_model_result>(m, "python_continuous_model_result")
       .def(py::init<>())
@@ -312,7 +314,8 @@ PYBIND11_MODULE(bmdscore, m) {
       .def_readwrite("alpha", &python_nested_analysis::alpha)
       .def_readwrite("numBootRuns", &python_nested_analysis::numBootRuns)
       .def_readwrite("iterations", &python_nested_analysis::iterations)
-      .def_readwrite("seed", &python_nested_analysis::seed);
+      .def_readwrite("seed", &python_nested_analysis::seed)
+      .def_readwrite("penalizeAIC", &python_nested_analysis::penalizeAIC);
 
   py::class_<python_nested_result>(m, "python_nested_result")
       .def(py::init<>())

--- a/src/tests/src/test_cpp.cpp
+++ b/src/tests/src/test_cpp.cpp
@@ -51,7 +51,7 @@ int main(void) {
   //  runPythonDichoMA();
   //  runPythonContAnalysis();
   //  runPythonMultitumorAnalysis();
-    runPythonNestedAnalysis();
+  runPythonNestedAnalysis();
   //  Nlogist_probs_test();
   //  Nlogist_lk_test();
   ////  runTestMultitumorModel();

--- a/src/tests/src/test_cpp.cpp
+++ b/src/tests/src/test_cpp.cpp
@@ -51,7 +51,7 @@ int main(void) {
   //  runPythonDichoMA();
   //  runPythonContAnalysis();
   //  runPythonMultitumorAnalysis();
-  runPythonNestedAnalysis();
+    runPythonNestedAnalysis();
   //  Nlogist_probs_test();
   //  Nlogist_lk_test();
   ////  runTestMultitumorModel();
@@ -413,6 +413,7 @@ void runOldDichoAnalysis() {
   int degree = 3;                     // for multistage only
   double BMR = 0.1;
   double alpha = 0.05;
+  bool penalizeAIC = true;
   ///////////////////////////////
   // dicho data - dose, N, incidence
   ///////////////////////////////
@@ -886,7 +887,7 @@ void runOldDichoAnalysis() {
   aod.pvFit = pvFit;
   aod.pvRed = pvRed;
 
-  runBMDSDichoAnalysis(&anal, &res, &gof, &bmdsRes, &aod);
+  runBMDSDichoAnalysis(&anal, &res, &gof, &bmdsRes, &aod, &penalizeAIC);
 
   printf("tlink bmdsRes.validResult = %s\n", bmdsRes.validResult ? "valid" : "invalid");
   if (bmdsRes.validResult || showResultsOverride) {
@@ -967,6 +968,7 @@ void runPythonDichoAnalysis() {
   int degree = 3;                        // for multistage only
   double BMR = 0.1;
   double alpha = 0.05;
+  double penalizeAIC = false;
   ///////////////////////////////
   // dicho data - dose, N, incidence
   ///////////////////////////////
@@ -1065,6 +1067,7 @@ void runPythonDichoAnalysis() {
 
   // struct dichotomous_analysis anal;
   struct python_dichotomous_analysis anal;
+  anal.penalizeAIC = penalizeAIC;
 
   int numDataRows = sizeof(D) / sizeof(D[0]);
 
@@ -2107,6 +2110,7 @@ void runOldContAnalysis() {
   bool restricted = true;           // only used for frequentist models
   enum distribution dist = normal;  // normal, normal_ncv, log_normal
   bool detectAdvDir = true;         // if false then need to set isIncreasing
+  bool penalizeAIC = true;
   // isIncreasing = true;
 
   int degree = 2;  // for polynomial only
@@ -3093,7 +3097,7 @@ void runOldContAnalysis() {
 
   printf("\n\n");
   printf("calling runBMDSContAnalysis\n");
-  runBMDSContAnalysis(&anal, &res, &BMDSres, &aod, &gof, &detectAdvDir, &restricted);
+  runBMDSContAnalysis(&anal, &res, &BMDSres, &aod, &gof, &detectAdvDir, &restricted, &penalizeAIC);
 
   if (detectAdvDir) {
     printf("auto adverse direction: %s\n", anal.isIncreasing ? "increasing" : "decreasing");
@@ -3192,6 +3196,7 @@ void runPythonContAnalysis() {
   bool restricted = true;           // only used for frequentist models
   enum distribution dist = normal;  // normal, normal_ncv, log_normal
   bool detectAdvDir = true;         // if false then need to set isIncreasing
+  bool penalizeAIC = true;
   // isIncreasing = true;
 
   int degree = 2;  // for polynomial only
@@ -3482,6 +3487,7 @@ void runPythonContAnalysis() {
 
   // struct continuous_analysis anal;
   struct python_continuous_analysis anal;
+  anal.penalizeAIC = penalizeAIC;
   int numDataRows = sizeof(D) / sizeof(D[0]);
 
   if (!detectAdvDir) {
@@ -4956,6 +4962,7 @@ void runPythonNestedAnalysis() {
   struct python_nested_analysis pyAnal;
   // pyAnal.model = nlogistic;
   pyAnal.model = nctr;
+  pyAnal.penalizeAIC = false;
   bool isRestricted = true;
 
   // nested.dax

--- a/src/unitTests/integration_tests.cpp
+++ b/src/unitTests/integration_tests.cpp
@@ -32,6 +32,7 @@ void runPythonDichoAnalysis() {
   int degree = 3;
   double BMR = 0.1;
   double alpha = 0.05;
+  bool penalizeAIC = true;
   std::vector<double> D{0, 50, 100, 150, 200};
   std::vector<double> Y{0, 5, 30, 65, 90};
   std::vector<double> N{100, 100, 100, 100, 100};
@@ -39,7 +40,7 @@ void runPythonDichoAnalysis() {
   struct python_dichotomous_analysis anal;
   struct python_dichotomous_model_result res;
   createDichoAnalysisStructs(
-      model, modelType, restricted, BMD_type, degree, BMR, alpha, D, Y, N, &anal, &res
+      model, modelType, restricted, BMD_type, degree, BMR, alpha, penalizeAIC, D, Y, N, &anal, &res
   );
 
   pythonBMDSDicho(&anal, &res);
@@ -300,8 +301,8 @@ std::vector<double> getMultitumorPrior(int degree, int prior_cols) {
 
 void createDichoAnalysisStructs(
     dich_model model, int modelType, bool restricted, int BMD_type, int degree, double BMR,
-    double alpha, std::vector<double> &D, std::vector<double> &Y, std::vector<double> &N,
-    python_dichotomous_analysis *anal, python_dichotomous_model_result *res
+    double alpha, bool penalizeAIC, std::vector<double> &D, std::vector<double> &Y,
+    std::vector<double> &N, python_dichotomous_analysis *anal, python_dichotomous_model_result *res
 ) {
   int prCols = 5;
   int dist_numE = 200;
@@ -528,6 +529,7 @@ void createDichoAnalysisStructs(
   anal->prior_cols = prCols;
   anal->n = numDataRows;
   anal->degree = degree;
+  anal->penalizeAIC = penalizeAIC;
 
   res->model = anal->model;
   res->dist_numE = dist_numE;

--- a/src/unitTests/integration_tests.h
+++ b/src/unitTests/integration_tests.h
@@ -18,8 +18,8 @@ void printContModResult(
 );
 void createDichoAnalysisStructs(
     dich_model model, int modelType, bool restricted, int BMD_type, int degree, double BMR,
-    double alpha, std::vector<double> &D, std::vector<double> &Y, std::vector<double> &N,
-    python_dichotomous_analysis *anal, python_dichotomous_model_result *res
+    double alpha, bool penalizeAIC, std::vector<double> &D, std::vector<double> &Y,
+    std::vector<double> &N, python_dichotomous_analysis *anal, python_dichotomous_model_result *res
 );
 void createContAnalysisStructs(
     cont_model model, int modelType, bool restricted, distribution dist, bool detectAdvDir,

--- a/src/unitTests/unit_tests.cpp
+++ b/src/unitTests/unit_tests.cpp
@@ -344,7 +344,6 @@ void cont_AIC_penalty_test() {
 }
 
 void dicho_AIC_penalty_test() {
-  int estParmCount;
   struct dichotomous_analysis anal;
   anal.parms = 4;
   double prior[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -18, 0, 0, 0, 18, 1e4, 1e4, 1e4};
@@ -360,12 +359,12 @@ void dicho_AIC_penalty_test() {
 
   bool penalizeAIC;
   penalizeAIC = true;
-  calcDichoAIC(&anal, &res, &bmdsRes, estParmCount, penalizeAIC);
+  calcDichoAIC(&anal, &res, &bmdsRes, penalizeAIC);
 
   double AIC_penalized = bmdsRes.AIC;
 
   penalizeAIC = false;
-  calcDichoAIC(&anal, &res, &bmdsRes, estParmCount, penalizeAIC);
+  calcDichoAIC(&anal, &res, &bmdsRes, penalizeAIC);
   double AIC_unpenalized = bmdsRes.AIC;
 
   essentiallyEqual(AIC_unpenalized - 2, AIC_penalized, 1e-6);

--- a/src/unitTests/unit_tests.cpp
+++ b/src/unitTests/unit_tests.cpp
@@ -15,6 +15,7 @@ int run_all_unitTests() {
   multitumor_eq_constraint_test();
   dicho_AIC_penalty_test();
   cont_AIC_penalty_test();
+  nested_AIC_penalty_test();
   return 0;
 }
 
@@ -370,4 +371,17 @@ void dicho_AIC_penalty_test (){
 
 
   essentiallyEqual(AIC_unpenalized - 2,  AIC_penalized, 1e-6);
+}
+
+void nested_AIC_penalty_test (){
+  double fitted_LL = -269.735;
+  double fitted_df = 35;
+  double red_df = 38;
+  int numBounded = 5;
+  
+  double AIC_penalized = calcNestedAIC(fitted_LL, fitted_df, red_df, numBounded, true);
+  double AIC_unpenalized = calcNestedAIC(fitted_LL, fitted_df, red_df, numBounded, false);
+
+  essentiallyEqual(AIC_unpenalized - 2*numBounded, AIC_penalized, 1e-6);
+
 }

--- a/src/unitTests/unit_tests.cpp
+++ b/src/unitTests/unit_tests.cpp
@@ -13,6 +13,8 @@ int run_all_unitTests() {
   // Nctr_probs_test();
   multitumor_ineq_constraint_test();
   multitumor_eq_constraint_test();
+  dicho_AIC_penalty_test();
+  cont_AIC_penalty_test();
   return 0;
 }
 
@@ -311,4 +313,61 @@ void multitumor_eq_constraint_test() {
   for (int i = 0; i < grad.size(); i++) {
     essentiallyEqual(grad[i], expGrad[i], 1e-6);
   }
+}
+
+void cont_AIC_penalty_test (){
+  struct continuous_analysis anal;
+  anal.parms = 4;
+  double prior[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0.1, 1, 0.2, 1, -100, -100, 1, -18, 100, 100, 18,  18};
+  anal.prior = prior;
+  anal.model = power;
+
+  struct BMDS_results bmdsRes;
+  struct continuous_model_result res;
+  double parm[4] = {5.05487, -0.0260177, 1, 0.698018};
+  res.nparms = 4;
+  res.parms = parm;
+  res.max = 175.027;
+
+  bool penalizeAIC;
+  penalizeAIC = true;
+  calcContAIC(&anal, &res, &bmdsRes, penalizeAIC);
+
+  double AIC_penalized = bmdsRes.AIC;
+
+  penalizeAIC = false;
+  calcContAIC(&anal, &res, &bmdsRes, penalizeAIC);
+  double AIC_unpenalized = bmdsRes.AIC;
+
+
+  essentiallyEqual(AIC_unpenalized - 2,  AIC_penalized, 1e-6);
+}
+
+void dicho_AIC_penalty_test (){
+  int estParmCount;
+  struct dichotomous_analysis anal;
+  anal.parms = 4;
+  double prior[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -18, 0, 0, 0, 18, 1e4, 1e4, 1e4};
+  anal.prior = prior;
+  anal.model = d_multistage;
+
+  struct BMDS_results bmdsRes;
+  struct dichotomous_model_result res;
+  double parm[4] = {1.523e-8, 0, 1.05565e-5, 2.39079e-7};
+  res.nparms = 4;
+  res.parms = parm;
+  res.max = 178.237;
+
+  bool penalizeAIC;
+  penalizeAIC = true;
+  calcDichoAIC(&anal, &res, &bmdsRes, estParmCount, penalizeAIC);
+
+  double AIC_penalized = bmdsRes.AIC;  
+
+  penalizeAIC = false;
+  calcDichoAIC(&anal, &res, &bmdsRes, estParmCount, penalizeAIC);
+  double AIC_unpenalized = bmdsRes.AIC;
+
+
+  essentiallyEqual(AIC_unpenalized - 2,  AIC_penalized, 1e-6);
 }

--- a/src/unitTests/unit_tests.cpp
+++ b/src/unitTests/unit_tests.cpp
@@ -316,10 +316,10 @@ void multitumor_eq_constraint_test() {
   }
 }
 
-void cont_AIC_penalty_test (){
+void cont_AIC_penalty_test() {
   struct continuous_analysis anal;
   anal.parms = 4;
-  double prior[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0.1, 1, 0.2, 1, -100, -100, 1, -18, 100, 100, 18,  18};
+  double prior[20] = {0, 0, 0, 0, 0, 0, 0, 0, 0.1, 1, 0.2, 1, -100, -100, 1, -18, 100, 100, 18, 18};
   anal.prior = prior;
   anal.model = power;
 
@@ -340,11 +340,10 @@ void cont_AIC_penalty_test (){
   calcContAIC(&anal, &res, &bmdsRes, penalizeAIC);
   double AIC_unpenalized = bmdsRes.AIC;
 
-
-  essentiallyEqual(AIC_unpenalized - 2,  AIC_penalized, 1e-6);
+  essentiallyEqual(AIC_unpenalized - 2, AIC_penalized, 1e-6);
 }
 
-void dicho_AIC_penalty_test (){
+void dicho_AIC_penalty_test() {
   int estParmCount;
   struct dichotomous_analysis anal;
   anal.parms = 4;
@@ -363,25 +362,23 @@ void dicho_AIC_penalty_test (){
   penalizeAIC = true;
   calcDichoAIC(&anal, &res, &bmdsRes, estParmCount, penalizeAIC);
 
-  double AIC_penalized = bmdsRes.AIC;  
+  double AIC_penalized = bmdsRes.AIC;
 
   penalizeAIC = false;
   calcDichoAIC(&anal, &res, &bmdsRes, estParmCount, penalizeAIC);
   double AIC_unpenalized = bmdsRes.AIC;
 
-
-  essentiallyEqual(AIC_unpenalized - 2,  AIC_penalized, 1e-6);
+  essentiallyEqual(AIC_unpenalized - 2, AIC_penalized, 1e-6);
 }
 
-void nested_AIC_penalty_test (){
+void nested_AIC_penalty_test() {
   double fitted_LL = -269.735;
   double fitted_df = 35;
   double red_df = 38;
   int numBounded = 5;
-  
+
   double AIC_penalized = calcNestedAIC(fitted_LL, fitted_df, red_df, numBounded, true);
   double AIC_unpenalized = calcNestedAIC(fitted_LL, fitted_df, red_df, numBounded, false);
 
-  essentiallyEqual(AIC_unpenalized - 2*numBounded, AIC_penalized, 1e-6);
-
+  essentiallyEqual(AIC_unpenalized - 2 * numBounded, AIC_penalized, 1e-6);
 }

--- a/src/unitTests/unit_tests.h
+++ b/src/unitTests/unit_tests.h
@@ -9,3 +9,4 @@ void multitumor_ineq_constraint_test();
 void multitumor_eq_constraint_test();
 void cont_AIC_penalty_test();
 void dicho_AIC_penalty_test();
+void nested_AIC_penalty_test();

--- a/src/unitTests/unit_tests.h
+++ b/src/unitTests/unit_tests.h
@@ -7,3 +7,5 @@ void Nctr_probs_test();
 void Nlogist_lk_test();
 void multitumor_ineq_constraint_test();
 void multitumor_eq_constraint_test();
+void cont_AIC_penalty_test();
+void dicho_AIC_penalty_test();

--- a/tests/test_pybmds/models/test_continuous.py
+++ b/tests/test_pybmds/models/test_continuous.py
@@ -127,6 +127,17 @@ class TestBmdModelContinuous:
         model = continuous.Power(cdataset, settings=dict(disttype=DistType.normal_ncv))
         assert model.settings.disttype == DistType.normal_ncv
 
+    def test_penalize_aic_on_boundary(self, cdataset2):
+        model_penalize = continuous.Power(cdataset2, settings=dict(penalize_aic_on_boundary=True))
+        model_penalize.execute()
+        model_unpenalized = continuous.Power(
+            cdataset2, settings=dict(penalize_aic_on_boundary=False)
+        )
+        model_unpenalized.execute()
+        assert model_penalize.results.fit.aic + 2 == pytest.approx(
+            model_unpenalized.results.fit.aic, abs=0.01
+        )
+
 
 def test_fit_parameters(cdataset2):
     # check fit parameters for continuous modeling

--- a/tests/test_pybmds/models/test_dichotomous.py
+++ b/tests/test_pybmds/models/test_dichotomous.py
@@ -84,6 +84,15 @@ class TestBmdModelDichotomous:
         model.execute()
         return model.cdf_plot()
 
+    def test_penalize_aic_on_boundary(self, ddataset):
+        model_penalize = Multistage(ddataset, settings=dict(penalize_aic_on_boundary=True))
+        model_penalize.execute()
+        model_unpenalized = Multistage(ddataset, settings=dict(penalize_aic_on_boundary=False))
+        model_unpenalized.execute()
+        assert model_penalize.results.fit.aic + 2 == pytest.approx(
+            model_unpenalized.results.fit.aic, abs=0.01
+        )
+
 
 def test_dichotomous_models(ddataset2):
     # compare bmd, bmdl, bmdu, aic values

--- a/tests/test_pybmds/models/test_dichotomous.py
+++ b/tests/test_pybmds/models/test_dichotomous.py
@@ -85,12 +85,18 @@ class TestBmdModelDichotomous:
         return model.cdf_plot()
 
     def test_penalize_aic_on_boundary(self, ddataset):
-        model_penalize = Multistage(ddataset, settings=dict(penalize_aic_on_boundary=True))
-        model_penalize.execute()
-        model_unpenalized = Multistage(ddataset, settings=dict(penalize_aic_on_boundary=False))
-        model_unpenalized.execute()
-        assert model_penalize.results.fit.aic + 2 == pytest.approx(
-            model_unpenalized.results.fit.aic, abs=0.01
+        penalized = Multistage(ddataset, settings=dict(penalize_aic_on_boundary=True))
+        penalized.execute()
+        unpenalized = Multistage(ddataset, settings=dict(penalize_aic_on_boundary=False))
+        unpenalized.execute()
+
+        assert np.isclose(
+            penalized.results.parameters.values,
+            unpenalized.results.parameters.values,
+        ).all()
+        assert np.isclose(
+            penalized.results.fit.aic + 2,
+            unpenalized.results.fit.aic,
         )
 
 

--- a/tests/test_pybmds/models/test_nested_dichotomous.py
+++ b/tests/test_pybmds/models/test_nested_dichotomous.py
@@ -1,5 +1,7 @@
 from textwrap import dedent
 
+import pytest
+
 from pybmds.constants import PriorClass
 from pybmds.models import nested_dichotomous
 
@@ -86,6 +88,19 @@ class TestNestedLogistic:
         result = analysis.execute()
         assert result.has_completed is True
         assert result.bmd > 0
+
+    def test_penalize_aic_on_boundary(self, nd_dataset4):
+        model_penalize = nested_dichotomous.NestedLogistic(
+            nd_dataset4, settings=dict(penalize_aic_on_boundary=True)
+        )
+        model_penalize.execute()
+        model_unpenalized = nested_dichotomous.NestedLogistic(
+            nd_dataset4, settings=dict(penalize_aic_on_boundary=False)
+        )
+        model_unpenalized.execute()
+        assert model_penalize.results.aic + 2 == pytest.approx(
+            model_unpenalized.results.aic, abs=0.01
+        )
 
 
 class TestNctr:

--- a/tests/test_pybmds/types/test_continuous.py
+++ b/tests/test_pybmds/types/test_continuous.py
@@ -94,4 +94,4 @@ class TestContinuousAnalysisCPPStructs:
         text = str(model.structs)
         assert """- python_continuous_analysis""" in text
         assert """- python_continuous_model_result""" in text
-        assert len(text.splitlines()) == 71
+        assert len(text.splitlines()) == 72

--- a/tests/test_pybmds/types/test_dichotomous.py
+++ b/tests/test_pybmds/types/test_dichotomous.py
@@ -13,7 +13,7 @@ class TestDichotomousAnalysisCPPStructs:
         text = str(model.structs)
         assert """- python_dichotomous_analysis""" in text
         assert """- python_dichotomous_model_result""" in text
-        assert len(text.splitlines()) == 64
+        assert len(text.splitlines()) == 65
 
 
 class TestDichotomousModelSettings:

--- a/tests/test_pybmds/types/test_ma.py
+++ b/tests/test_pybmds/types/test_ma.py
@@ -10,4 +10,4 @@ class TestDichotomousModelAverage:
         text = str(session.model_average.structs)
         assert "- python_dichotomous_analysis" in text
         assert "- python_dichotomousMA_result" in text
-        assert len(text.splitlines()) == 30
+        assert len(text.splitlines()) == 31


### PR DESCRIPTION
This adds a new property penalizeAIC that allows users to control whether parameters hitting a bound will affect the AIC calculation.

In `pybmds`, the default value for penalizing is True, which is consistent with previous behavior. This may change in the future.