### PR TITLE
update to version 3.0.0 of pybind11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ ExternalProject_Add(
         pybind11
         PREFIX .
         GIT_REPOSITORY "https://github.com/pybind/pybind11.git"
-        GIT_TAG "a2e59f0e7065404b44dfe92a28aca47ba1378dc4" # v2.13.6
+        GIT_TAG "ed5057ded698e305210269dafa57574ecf964483" # v3.0.0
         SOURCE_DIR "${CMAKE_BINARY_DIR}/third-party/pybind11"
         # Override default steps with no action, we just want the clone step.
         UPDATE_COMMAND ""
@@ -80,7 +80,7 @@ set(FETCHCONTENT_QUIET FALSE)
 
 FetchContent_Declare(
   pybind11
-  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v3.0.0.tar.gz
 )
 
 FetchContent_GetProperties(pybind11)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
   "poethepoet~=0.32.2",
   "coverage~=7.6.4",
   "mypy~=1.13.0",
-  "pybind11==2.13.6",
+  "pybind11==3.0.0",
   "pytest-mpl~=0.17.0",
   "pytest~=8.3.3",
   "ruff~=0.7.1",
@@ -63,7 +63,7 @@ docs = [
 
 [build-system]
 requires = [
-  "pybind11==2.13.6",
+  "pybind11==3.0.0",
   "setuptools~=75.3.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Required to build python3.14 wheels.