### PR TITLE
update to cibuildwheel 3.1.3

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,7 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-14]
+        # os: [ubuntu-22.04, windows-2022, macos-14]  # TODO - uncomment this line
+        os: [ubuntu-22.04]  # TODO - remove this line
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,16 +18,8 @@ jobs:
         os: [ubuntu-22.04, windows-2022, macos-14]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Show wheels that will be built
-        run: |
-          python -m pip install cibuildwheel==2.21.1
-          cibuildwheel --print-build-identifiers
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
+        uses: pypa/cibuildwheel@v3.1.3
         env:
           MACOSX_DEPLOYMENT_TARGET: "14.0"
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - '*'
   workflow_dispatch:
-  pull_request:
+  pull_request:  # TODO - remove this line
 
 env:
   CIBW_ARCHS: "auto64"
@@ -22,33 +22,41 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-14]
-        CIBW_BEFORE_BUILD:
-          ubuntu-22.04: "tools/cibuildwheel-linux.sh"
-          windows-2022: "bash tools/windows_ci.sh"
-          macos-14: "tools/cibuildwheel-mac.sh"
-        EIGEN_DIR:
-          ubuntu-22.04: "/usr/include/eigen3"
-          windows-2022: "D:/a/bmds/bmds/deps/eigen"
-          macos-14: "/opt/homebrew/Cellar/eigen/3.4.0_1/include/eigen3"
-        NLOPT_DIR:
-          ubuntu-22.04: "/usr/local/lib64/"
-          windows-2022: "D:/a/bmds/bmds/deps/nlopt/src/api;D:/a/bmds/bmds/deps/nlopt/build/Release;D:/a/bmds/bmds/deps/nlopt/build"
-          macos-14: "/opt/homebrew/Cellar/nlopt/2.7.1/include"
-        GSL_DIR:
-          windows-2022: "D:/a/bmds/bmds/deps/gsl/build/Release;D:/a/bmds/bmds/deps/gsl/build"
-          macos-14: "/opt/homebrew/Cellar/gsl/2.7.1"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set environment variables for Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          echo "CIBW_BEFORE_BUILD=tools/cibuildwheel-linux.sh" >> $GITHUB_ENV
+          echo "EIGEN_DIR=/usr/include/eigen3" >> $GITHUB_ENV
+          echo "NLOPT_DIR=/usr/local/lib64/" >> $GITHUB_ENV
+
+      - name: Set environment variables for Windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "CIBW_BEFORE_BUILD=bash tools/windows_ci.sh" >> $GITHUB_ENV
+          echo "EIGEN_DIR=D:/a/bmds/bmds/deps/eigen" >> $GITHUB_ENV
+          echo "NLOPT_DIR=D:/a/bmds/bmds/deps/nlopt/src/api;D:/a/bmds/bmds/deps/nlopt/build/Release;D:/a/bmds/bmds/deps/nlopt/build" >> $GITHUB_ENV
+          echo "GSL_DIR=D:/a/bmds/bmds/deps/gsl/build/Release;D:/a/bmds/bmds/deps/gsl/build" >> $GITHUB_ENV
+
+      - name: Set environment variables for macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          echo "CIBW_BEFORE_BUILD=tools/cibuildwheel-mac.sh" >> $GITHUB_ENV
+          echo "EIGEN_DIR=/opt/homebrew/Cellar/eigen/3.4.0_1/include/eigen3" >> $GITHUB_ENV
+          echo "NLOPT_DIR=/opt/homebrew/Cellar/nlopt/2.7.1/include" >> $GITHUB_ENV
+          echo "GSL_DIR=/opt/homebrew/Cellar/gsl/2.7.1" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.3
-        env:
-          CIBW_BEFORE_BUILD: ${{ matrix.CIBW_BEFORE_BUILD[matrix.os] }}
-          EIGEN_DIR: ${{ matrix.EIGEN_DIR[matrix.os] }}
-          NLOPT_DIR: ${{ matrix.NLOPT_DIR[matrix.os] }}
-          GSL_DIR: ${{ matrix.GSL_DIR[matrix.os] }}
-          MACOSX_DEPLOYMENT_TARGET: "14.0"
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-linux-${{ strategy.job-index }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,6 +16,10 @@ env:
   CIBW_TEST_REQUIRES: "pytest pytest-mpl"
   CIBW_TEST_COMMAND: "pytest {project}/tests"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
 
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,6 +7,14 @@ on:
     tags:
       - '*'
   workflow_dispatch:
+  pull_request:
+
+env:
+  CIBW_ARCHS: "auto64"
+  CIBW_BUILD: "cp311-* cp312-* cp313-*"
+  CIBW_SKIP: "*-win32 *-win_arm64 *musllinux* *i686 *-macosx_x86_64 *-macosx_universal2"
+  CIBW_TEST_REQUIRES: "pytest pytest-mpl"
+  CIBW_TEST_COMMAND: "pytest {project}/tests"
 
 jobs:
 
@@ -16,19 +24,38 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2022, macos-14]
+        CIBW_BEFORE_BUILD:
+          ubuntu-22.04: "tools/cibuildwheel-linux.sh"
+          windows-2022: "bash tools/windows_ci.sh"
+          macos-14: "tools/cibuildwheel-mac.sh"
+        EIGEN_DIR:
+          ubuntu-22.04: "/usr/include/eigen3"
+          windows-2022: "D:/a/bmds/bmds/deps/eigen"
+          macos-14: "/opt/homebrew/Cellar/eigen/3.4.0_1/include/eigen3"
+        NLOPT_DIR:
+          ubuntu-22.04: "/usr/local/lib64/"
+          windows-2022: "D:/a/bmds/bmds/deps/nlopt/src/api;D:/a/bmds/bmds/deps/nlopt/build/Release;D:/a/bmds/bmds/deps/nlopt/build"
+          macos-14: "/opt/homebrew/Cellar/nlopt/2.7.1/include"
+        GSL_DIR:
+          windows-2022: "D:/a/bmds/bmds/deps/gsl/build/Release;D:/a/bmds/bmds/deps/gsl/build"
+          macos-14: "/opt/homebrew/Cellar/gsl/2.7.1"
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.3
         env:
+          CIBW_BEFORE_BUILD: ${{ matrix.CIBW_BEFORE_BUILD[matrix.os] }}
+          EIGEN_DIR: ${{ matrix.EIGEN_DIR[matrix.os] }}
+          NLOPT_DIR: ${{ matrix.NLOPT_DIR[matrix.os] }}
+          GSL_DIR: ${{ matrix.GSL_DIR[matrix.os] }}
           MACOSX_DEPLOYMENT_TARGET: "14.0"
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: cibw-wheels-linux-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   merge_wheels:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build_wheels
     steps:
       - name: Merge Artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 .ruff_cache/
 .vscode/
 build/
+deps/
 dist/
 htmlcov/
 venv/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This builds pybmds
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 
 project(pybind11-download NONE)
 set(PYBIND11_FINDPYTHON OFF)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,43 +68,6 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tool.cibuildwheel]
-archs = ["auto64"]
-build = ["cp311-*", "cp312-*", "cp313-*"]
-skip = [
-  "*-win32",
-  "*-win_arm64",
-  "*musllinux*",
-  "*i686",
-  "*-macosx_x86_64",
-  "*-macosx_universal2",
-]
-test-requires = ["pytest", "pytest-mpl"]
-test-command = "pytest {project}/tests"
-
-[tool.cibuildwheel.windows]
-before-build = "bash tools/windows_ci.sh"
-
-[tool.cibuildwheel.windows.environment]
-EIGEN_DIR="D:/a/bmds/bmds/deps/eigen"
-NLOPT_DIR="D:/a/bmds/bmds/deps/nlopt/src/api;D:/a/bmds/bmds/deps/nlopt/build/Release;D:/a/bmds/bmds/deps/nlopt/build"
-GSL_DIR="D:/a/bmds/bmds/deps/gsl/build/Release;D:/a/bmds/bmds/deps/gsl/build"
-
-[tool.cibuildwheel.linux]
-before-build = "tools/cibuildwheel-linux.sh"
-
-[tool.cibuildwheel.linux.environment]
-EIGEN_DIR="/usr/include/eigen3"
-NLOPT_DIR="/usr/local/lib64/"
-
-[tool.cibuildwheel.macos]
-before-build = "tools/cibuildwheel-mac.sh"
-
-[tool.cibuildwheel.macos.environment]
-EIGEN_DIR="/opt/homebrew/Cellar/eigen/3.4.0_1/include/eigen3"
-GSL_DIR="/opt/homebrew/Cellar/gsl/2.7.1"
-NLOPT_DIR="/opt/homebrew/Cellar/nlopt/2.7.1/include"
-
 [tool.coverage.report]
 exclude_also = [
   "if __name__ == .__main__.:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,6 @@ skip = [
   "*-macosx_x86_64",
   "*-macosx_universal2",
 ]
-manylinux-x86_64-image = "manylinux_2_28"
-manylinux-aarch64-image = "manylinux_2_28"
 test-requires = ["pytest", "pytest-mpl"]
 test-command = "pytest {project}/tests"
 
@@ -98,8 +96,6 @@ before-build = "tools/cibuildwheel-linux.sh"
 [tool.cibuildwheel.linux.environment]
 EIGEN_DIR="/usr/include/eigen3"
 NLOPT_DIR="/usr/local/lib64/"
-CMAKE_C_COMPILER="/opt/rh/gcc-toolset-12/root/usr/bin/gcc"
-CMAKE_CXX_COMPILER="/opt/rh/gcc-toolset-12/root/usr/bin/g++"
 
 [tool.cibuildwheel.macos]
 before-build = "tools/cibuildwheel-mac.sh"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This builds bmdscore + tests
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/tools/cibuildwheel-linux.sh
+++ b/tools/cibuildwheel-linux.sh
@@ -7,5 +7,5 @@ yum install -y cmake gsl-devel eigen3-devel
 
 cp ./vendor/nlopt-2.7.1.tar.gz ~
 cd ~
-tar -xf nlopt-2.7.1.tar.gz && cd nlopt-2.7.1 && mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=OFF .. && make install
+tar -xf nlopt-2.7.1.tar.gz && cd nlopt-2.7.1 && mkdir build && cd build && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.15 .. && make install
 cd $GITHUB_WORKSPACE

--- a/tools/linux_ci_env.sh
+++ b/tools/linux_ci_env.sh
@@ -2,6 +2,4 @@
 
 export EIGEN_DIR="/usr/include/eigen3"
 export NLOPT_DIR="/usr/lib/x86_64-linux-gnu/"
-export CMAKE_C_COMPILER="/usr/bin/gcc-11"
-export CMAKE_CXX_COMPILER="/usr/bin/g++-11"
 export TEST_EXC="'/usr/include/*'"


### PR DESCRIPTION
Update to the latest version of cibuildwheel, which should allow us to build Python3.14 wheels in the future once. 

Changelog: https://github.com/pypa/cibuildwheel#changelog
