### PR TITLE
Add validation checks for zero stdev

### DIFF
--- a/src/pybmds/datasets/continuous.py
+++ b/src/pybmds/datasets/continuous.py
@@ -27,12 +27,10 @@ class ContinuousSummaryDataMixin:
             raise ValueError("N must be positive and non-zero")
 
         if np.min(self.stdevs) <= 0:
-            raise ValueError("Stdev must be be greater than zero")
+            raise ValueError("Stdev must be greater than zero")
 
         if self.num_dose_groups < self.MINIMUM_DOSE_GROUPS:
-            raise ValueError(
-                f"Must have {self.MINIMUM_DOSE_GROUPS} or more dose groups after dropping doses"
-            )
+            raise ValueError(f"Must have {self.MINIMUM_DOSE_GROUPS} or more dose groups")
 
     @property
     def is_increasing(self):
@@ -321,7 +319,7 @@ class ContinuousIndividualDataset(ContinuousSummaryDataMixin, DatasetBase):
 
     def _validate(self):
         if self.num_dose_groups < self.MINIMUM_DOSE_GROUPS:
-            raise ValueError(f"Must have more than {self.MINIMUM_DOSE_GROUPS} dose groups")
+            raise ValueError(f"Must have {self.MINIMUM_DOSE_GROUPS} or more dose groups")
 
         _, counts = np.unique(self.individual_doses, return_counts=True)
         if counts.min() <= 1:

--- a/src/pybmds/datasets/continuous.py
+++ b/src/pybmds/datasets/continuous.py
@@ -26,6 +26,9 @@ class ContinuousSummaryDataMixin:
         if np.min(self.ns) <= 0:
             raise ValueError("N must be positive and non-zero")
 
+        if np.min(self.stdevs) <= 0:
+            raise ValueError("Stdev must be be greater than zero")
+
         if self.num_dose_groups < self.MINIMUM_DOSE_GROUPS:
             raise ValueError(
                 f"Must have {self.MINIMUM_DOSE_GROUPS} or more dose groups after dropping doses"
@@ -317,14 +320,12 @@ class ContinuousIndividualDataset(ContinuousSummaryDataMixin, DatasetBase):
         )
 
     def _validate(self):
-        length = len(self.individual_doses)
-        if not all(len(lst) == length for lst in [self.individual_doses, self.responses]):
-            raise ValueError("All input lists must be same length")
-
         if self.num_dose_groups < self.MINIMUM_DOSE_GROUPS:
-            raise ValueError(
-                f"Must have {self.MINIMUM_DOSE_GROUPS} or more dose groups after dropping doses"
-            )
+            raise ValueError(f"Must have more than {self.MINIMUM_DOSE_GROUPS} dose groups")
+
+        _, counts = np.unique(self.individual_doses, return_counts=True)
+        if counts.min() <= 1:
+            raise ValueError("There must be more than one response for each dose group")
 
         self._validate_summary_data()
 

--- a/src/pybmds/datasets/dichotomous.py
+++ b/src/pybmds/datasets/dichotomous.py
@@ -58,9 +58,7 @@ class DichotomousDataset(DatasetBase):
             raise ValueError("Doses are not unique")
 
         if self.num_dose_groups < self.MINIMUM_DOSE_GROUPS:
-            raise ValueError(
-                f"Must have {self.MINIMUM_DOSE_GROUPS} or more dose groups after dropping doses"
-            )
+            raise ValueError(f"Must have {self.MINIMUM_DOSE_GROUPS} or more dose groups")
 
     def drop_dose(self):
         """

--- a/src/pybmds/datasets/nested_dichotomous.py
+++ b/src/pybmds/datasets/nested_dichotomous.py
@@ -53,9 +53,7 @@ class NestedDichotomousDataset(DatasetBase):
             raise ValueError("All input lists must be same length")
 
         if self.num_dose_groups < self.MINIMUM_DOSE_GROUPS:
-            raise ValueError(
-                f"Must have {self.MINIMUM_DOSE_GROUPS} or more dose groups after dropping doses"
-            )
+            raise ValueError(f"Must have {self.MINIMUM_DOSE_GROUPS} or more dose groups")
 
     def drop_dose(self):
         raise NotImplementedError("")

--- a/tests/test_pybmds/conftest.py
+++ b/tests/test_pybmds/conftest.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import numpy as np
 import pytest
 
 import pybmds
@@ -101,36 +100,6 @@ def ddataset3():
         doses=[0, 50, 100, 150, 200],
         ns=[10.1, 10.2, 10.3, 10.4, 10.5],
         incidences=[0.0, 2.5, 3.5, 7.5, 9.5],
-    )
-
-
-@pytest.fixture
-def anova_dataset():
-    variances = [
-        0.884408974,
-        0.975597151,
-        0.301068371,
-        0.879069846,
-        0.220161323,
-        0.841362172,
-        0.571939331,
-    ]
-    stdevs = np.power(np.array(variances), 0.5)
-    return pybmds.ContinuousDataset(
-        doses=[1, 2, 3, 4, 5, 6, 7],
-        ns=[8, 6, 6, 6, 6, 6, 6],
-        means=[9.9264, 10.18886667, 10.17755, 10.35711667, 10.02756667, 11.4933, 10.85275],
-        stdevs=stdevs.tolist(),
-    )
-
-
-@pytest.fixture
-def bad_anova_dataset():
-    return pybmds.ContinuousDataset(
-        doses=[0.0, 0.2, 1.5, 10.0],
-        means=[0.0, 0.0, 0.0, 0.67],
-        ns=[6, 6, 6, 4],
-        stdevs=[0.0, 0.0, 0.0, 0.67],
     )
 
 

--- a/tests/test_pybmds/datasets/test_continuous.py
+++ b/tests/test_pybmds/datasets/test_continuous.py
@@ -27,7 +27,7 @@ class TestContinuousSummaryDataset:
             pybmds.ContinuousDataset(doses=dummy4, ns=dummy3, means=dummy3, stdevs=dummy3)
         with pytest.raises(ValueError, match="N must be positive and non-zero"):
             pybmds.ContinuousDataset(doses=dummy3, ns=[0, 2, 3], means=dummy3, stdevs=dummy3)
-        with pytest.raises(ValueError, match="Stdev must be be greater than zero"):
+        with pytest.raises(ValueError, match="Stdev must be greater than zero"):
             pybmds.ContinuousDataset(doses=dummy3, ns=dummy3, means=dummy3, stdevs=[0, 1, 2])
 
     def test_extra_kwargs(self):
@@ -218,7 +218,7 @@ class TestContinuousIndividualDataset:
         with pytest.raises(ValueError, match="All arrays must be of the same length"):
             pybmds.ContinuousIndividualDataset(doses=[1, 2, 3, 4], responses=[1, 2, 3])
         # < 3 dose groups
-        with pytest.raises(ValueError, match="Must have more than 3 dose groups"):
+        with pytest.raises(ValueError, match="Must have 3 or more dose groups"):
             pybmds.ContinuousIndividualDataset(doses=[1, 2], responses=[1, 2])
         # n <= 1
         with pytest.raises(ValueError, match="more than one response for each dose group"):

--- a/tests/test_pybmds/datasets/test_continuous.py
+++ b/tests/test_pybmds/datasets/test_continuous.py
@@ -18,18 +18,17 @@ class TestContinuousSummaryDataset:
     def test_validation(self):
         # these should be valid
         pybmds.ContinuousDataset(doses=dummy3, ns=dummy3, means=dummy3, stdevs=dummy3)
-        # some data adjustments result in non-integer based counts
         pybmds.ContinuousDataset(doses=dummy3, ns=dummy3_floats, means=dummy3, stdevs=dummy3)
-        # these should raise errors
-        with pytest.raises((IndexError, ValueError)):
-            # insufficient number of dose groups
+
+        # these should raise exceptions
+        with pytest.raises(ValueError, match="Must have 3 or more dose groups"):
             pybmds.ContinuousDataset(doses=dummy2, ns=dummy2, means=dummy2, stdevs=dummy2)
-        with pytest.raises((IndexError, ValueError)):
-            # different sized lists
+        with pytest.raises(IndexError):
             pybmds.ContinuousDataset(doses=dummy4, ns=dummy3, means=dummy3, stdevs=dummy3)
-        with pytest.raises((IndexError, ValueError)):
-            # zero in ns data
+        with pytest.raises(ValueError, match="N must be positive and non-zero"):
             pybmds.ContinuousDataset(doses=dummy3, ns=[0, 2, 3], means=dummy3, stdevs=dummy3)
+        with pytest.raises(ValueError, match="Stdev must be be greater than zero"):
+            pybmds.ContinuousDataset(doses=dummy3, ns=dummy3, means=dummy3, stdevs=[0, 1, 2])
 
     def test_extra_kwargs(self):
         ds = pybmds.ContinuousDataset(
@@ -91,16 +90,10 @@ class TestContinuousSummaryDataset:
         ds = pybmds.ContinuousDataset(doses=dummy4, ns=dummy4, means=[0, 2, -1, 0], stdevs=dummy4)
         assert ds.is_increasing is True
 
-    def test_anova(self, anova_dataset, bad_anova_dataset):
-        # Check that anova generates expected output from original specifications.
-        report = anova_dataset.get_anova_report()
-        expected = "                     Tests of Interest    \n   Test    -2*log(Likelihood Ratio)  Test df        P-Value    \n   Test 1              22.2699         12           0.0346\n   Test 2               5.5741          6           0.4725\n   Test 3               5.5741          6           0.4725"
-        assert report == expected
-
-        # check bad anova dataset
-        report = bad_anova_dataset.get_anova_report()
-        expected = "ANOVA cannot be calculated for this dataset."
-        assert report == expected
+    def test_anova(self, cdataset):
+        actual = cdataset.get_anova_report()
+        expected = "                     Tests of Interest    \n   Test    -2*log(Likelihood Ratio)  Test df        P-Value    \n   Test 1              475.068          8                0\n   Test 2              15.4005          4         0.003939\n   Test 3              15.4005          4         0.003939"
+        assert actual == expected
 
     def test_dfile_outputs(self):
         ds = pybmds.ContinuousDataset(doses=dummy3, ns=dummy3, means=dummy3, stdevs=dummy3)
@@ -218,14 +211,18 @@ class TestContinuousSummaryDataset:
 class TestContinuousIndividualDataset:
     def test_validation(self):
         # these should be valid
-        pybmds.ContinuousIndividualDataset(doses=dummy3, responses=dummy3)
-        # these should raise errors
-        with pytest.raises((IndexError, ValueError)):
-            # different sized lists
-            pybmds.ContinuousIndividualDataset(doses=dummy4, responses=dummy3)
-        with pytest.raises((IndexError, ValueError)):
-            # also duplicate, but less than 2 dose-groups
-            pybmds.ContinuousIndividualDataset(doses=dummy3_dups, responses=dummy3)
+        pybmds.ContinuousIndividualDataset(
+            doses=[1, 1, 2, 2, 3, 3, 4, 4], responses=[1, 2, 3, 4, 5, 6, 7, 8]
+        )
+        # different sized lists
+        with pytest.raises(ValueError, match="All arrays must be of the same length"):
+            pybmds.ContinuousIndividualDataset(doses=[1, 2, 3, 4], responses=[1, 2, 3])
+        # < 3 dose groups
+        with pytest.raises(ValueError, match="Must have more than 3 dose groups"):
+            pybmds.ContinuousIndividualDataset(doses=[1, 2], responses=[1, 2])
+        # n <= 1
+        with pytest.raises(ValueError, match="more than one response for each dose group"):
+            pybmds.ContinuousIndividualDataset(doses=[1, 2, 3], responses=[1, 2, 3])
 
     def test_extra_kwargs(self):
         ds = pybmds.ContinuousIndividualDataset(
@@ -267,9 +264,11 @@ class TestContinuousIndividualDataset:
         assert ds.get_ylabel() == "Volume (ug/m3)"
 
     def test_dfile_outputs(self):
-        ds = pybmds.ContinuousIndividualDataset(doses=dummy3, responses=dummy3)
+        ds = pybmds.ContinuousIndividualDataset(
+            doses=[1, 1, 2, 2, 3, 3], responses=[1, 2, 3, 4, 5, 6]
+        )
         dfile = ds.as_dfile()
-        expected = "Dose Response\n1.000000 1.000000\n2.000000 2.000000\n3.000000 3.000000"
+        expected = "Dose Response\n1.000000 1.000000\n1.000000 2.000000\n2.000000 3.000000\n2.000000 4.000000\n3.000000 5.000000\n3.000000 6.000000"
         assert dfile == expected
 
     def test_ci_summary_stats(self, cidataset):


### PR DESCRIPTION
This PR raises a ValueError if a user tries to enter a standard deviation of 0.  This is undesirable because we have little confidence in the accuracy of results when a model has a standard deviation of 0.

It will also raise an error if a user tries to enter a continuous individual dataset and there's only one response at a dose-group. This is because the models convert individual response data to summary groups, and in doing so, it would result in a standard deviation of 0 for that dose group.