### PR TITLE
Fix `simulate_individual_dataset` for varying number of N

### DIFF
--- a/src/pybmds/datasets/continuous.py
+++ b/src/pybmds/datasets/continuous.py
@@ -206,9 +206,9 @@ class ContinuousDataset(ContinuousSummaryDataMixin, DatasetBase):
             doses.extend([dose] * n_int)
             responses.extend(values)
         return ContinuousIndividualDataset(
-            metadata=self.metadata,
             doses=np.array(doses).tolist(),
             responses=np.array(responses).tolist(),
+            **self.metadata.model_dump(),
         )
 
     def serialize(self) -> "ContinuousDatasetSchema":

--- a/src/pybmds/datasets/continuous.py
+++ b/src/pybmds/datasets/continuous.py
@@ -203,12 +203,12 @@ class ContinuousDataset(ContinuousSummaryDataMixin, DatasetBase):
                 max_iterations=max_iterations,
                 impose_positivity=impose_positivity,
             )
-            doses.append([dose] * n_int)
-            responses.append(values)
+            doses.extend([dose] * n_int)
+            responses.extend(values)
         return ContinuousIndividualDataset(
             metadata=self.metadata,
-            doses=np.array(doses).flatten().tolist(),
-            responses=np.array(responses).flatten().tolist(),
+            doses=np.array(doses).tolist(),
+            responses=np.array(responses).tolist(),
         )
 
     def serialize(self) -> "ContinuousDatasetSchema":

--- a/tests/test_pybmds/datasets/test_continuous.py
+++ b/tests/test_pybmds/datasets/test_continuous.py
@@ -186,7 +186,7 @@ class TestContinuousSummaryDataset:
     def test_simulate_individual_dataset(self):
         # test a simulated dataset is created fits desired distribution
         dataset = pybmds.ContinuousDataset(
-            doses=[0, 1, 5], ns=[10, 10, 10], means=[1, 2, 3], stdevs=[0.1, 0.2, 0.3]
+            doses=[0, 1, 5], ns=[10, 9, 8], means=[1, 2, 3], stdevs=[0.1, 0.2, 0.3]
         )
         fabricated = dataset.simulate_individual_dataset()
         assert isinstance(fabricated, pybmds.ContinuousIndividualDataset)


### PR DESCRIPTION
This PR fixes a bug in the simulate_individual_dataset method where the function was incorrectly constructing individual datasets when dose groups had varying sample sizes. The method was improperly nesting dose and response arrays instead of flattening them correctly.