### PR TITLE
build python 3.14 and linux ARM wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2022, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-14]
     steps:
       - uses: actions/checkout@v4
 
@@ -46,9 +46,9 @@ jobs:
           echo VCPKG_HOST_TRIPLET="$VCPKG_HOST_TRIPLET" >> $GITHUB_ENV
           echo $VCPKG_HOST_TRIPLET
 
-      - uses: pypa/cibuildwheel@v3.1.3
+      - uses: pypa/cibuildwheel@v3.3.0
         env:
-          CIBW_BUILD: "cp311-* cp312-* cp313-*"
+          CIBW_BUILD: "cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*musllinux* *win32*"
           CIBW_TEST_COMMAND: pytest {project}/tests
           CIBW_TEST_EXTRAS: dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
 ]
 requires-python = ">=3.11"


### PR DESCRIPTION
This pull request updates the build and packaging workflow to add support for Python 3.14 and ARM builds on Ubuntu, as well as upgrading dependencies for building wheels. The main changes focus on expanding platform and Python version compatibility.

Platform and Python version support:

* Added `ubuntu-24.04-arm` to the build matrix in `.github/workflows/wheels.yml`, enabling ARM linux Python wheels.
* Added Python 3.14 to the list of supported Python versions in both the `CIBW_BUILD` environment variable in `.github/workflows/wheels.yml` and the `classifiers` section of `pyproject.toml`. [[1]](diffhunk://#diff-75627befeafda60a526c116b32f6fdef9bf57bcf456f840d7592c1d6f13facb4L49-R51) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R18)

Dependency updates:

* Upgraded `pypa/cibuildwheel` from version 3.1.3 to 3.3.0 in `.github/workflows/wheels.yml` to support newer Python versions and platforms.